### PR TITLE
PhpAdapter supports prevention of array merging

### DIFF
--- a/tests/DI/Loader.include.phpt
+++ b/tests/DI/Loader.include.phpt
@@ -31,3 +31,16 @@ Assert::same( array(
 		'force' => array(1, 2),
 	),
 ), $data );
+
+$data = $config->load('files/loader.includes.php', 'common');
+
+Assert::same( array(
+	'parameters' => array(
+		'me' => array(
+			'loader.includes.child.php',
+		),
+		'scalar' => 1,
+		'list' => array(5, 6, 1, 2),
+		'force' => array(1, 2),
+	),
+), $data );

--- a/tests/DI/files/loader.includes.php
+++ b/tests/DI/files/loader.includes.php
@@ -1,0 +1,14 @@
+<?php
+
+return array(
+	'common' => array(
+		'includes' => array(
+			'loader.includes.child.php',
+		),
+		'parameters' => array(
+			'scalar' => 1,
+			'list' => array(1, 2),
+			'force!' => array(1, 2),
+		),
+	),
+);


### PR DESCRIPTION
Allows to use `!` trick in array's key to force overriding instead of merging.
