### PR TITLE
CompilerExtension: default empty costructor

### DIFF
--- a/src/DI/CompilerExtension.php
+++ b/src/DI/CompilerExtension.php
@@ -29,6 +29,11 @@ abstract class CompilerExtension extends Nette\Object
 	private $config;
 
 
+	public function __construct()
+	{
+	}
+
+
 	public function setCompiler(Compiler $compiler, $name)
 	{
 		$this->compiler = $compiler;


### PR DESCRIPTION
This prevents the following error and improves BC.

```
ReflectionException
Class Nette\DI\Extensions\PhpExtension does not have a constructor, so you cannot pass any constructor arguments
```

https://travis-ci.org/Kdyby/DoctrineCache/jobs/33112840
