### PR TITLE
Added support for setting priority of config files

### DIFF
--- a/src/DI/Config/Loader.php
+++ b/src/DI/Config/Loader.php
@@ -34,12 +34,15 @@ class Loader extends Nette\Object
 
 	/**
 	 * Reads configuration from file.
-	 * @param  string  file name
+	 * @param  string|array  file name or array with configuration
 	 * @param  string  optional section to load
 	 * @return array
 	 */
 	public function load($file, $section = NULL)
 	{
+		if (is_array($file)) {
+			return $file;
+		}
 		if (!is_file($file) || !is_readable($file)) {
 			throw new Nette\FileNotFoundException("File '$file' is missing or is not readable.");
 		}

--- a/tests/DI/ContainerFactory.generateConfig.phpt
+++ b/tests/DI/ContainerFactory.generateConfig.phpt
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Test: Nette\DI\Compiler and addExtension on loadConfiguration stage.
+ */
+use Nette\DI\ContainerFactory,
+	Tester\Assert;
+
+require __DIR__ . '/../bootstrap.php';
+
+$testNeon = <<<EOT
+foo: bar
+EOT;
+
+$files1 = array(
+	array(Tester\FileMock::create($testNeon, 'neon'), NULL),
+	array(array('foo' => 'fromFile'), NULL)
+);
+
+$files2 = array(
+	array(array('bar' => 'fromFile'), NULL)
+);
+
+$containerFactory = new Nette\DI\ContainerFactory(NULL);
+$containerFactory->config = array('foo' => 'baz');
+
+$m = $containerFactory->getReflection()->getMethod('generateConfig');
+$m->setAccessible(TRUE);
+
+$containerFactory->configFiles = $files1;
+Assert::equal($m->invoke($containerFactory), array('foo' => 'fromFile'));
+
+$containerFactory->configFiles = $files2;
+Assert::equal($m->invoke($containerFactory), array('foo' => 'baz', 'bar' => 'fromFile'));


### PR DESCRIPTION
Configuration in parameters section of config files had hardcoded higher priority than configuration passed from parameters array passed to Compiler::compile.
I found this unhandy, because sometimes I need to override some configuration from config files in my bootstrap. It seems more logical for me that dynamically built parameters in bootstrap.php have higher priority than static config files.
For backwards compatibility, I've made this behavior optional, configurable by ContainerFactory::$configPriority.
I issued another pull request for nette/bootstrap, which which should allow to set $configurator->configPriority in bootstrap without needing to manually call ContainerFactory.
