### PR TITLE
Idea: ContainerBuilder: avoid fopen if file is in opcode cache

### DIFF
--- a/src/DI/ContainerFactory.php
+++ b/src/DI/ContainerFactory.php
@@ -107,7 +107,14 @@ class ContainerFactory extends Nette\Object
 	private function loadClass()
 	{
 		$key = md5(serialize(array($this->config, $this->configFiles, $this->class, $this->parentClass)));
-		$handle = fopen($file = "$this->tempDirectory/$key.php", 'c+');
+		$file = "$this->tempDirectory/$key.php";
+
+		if (!$this->autoRebuild && function_exists('opcache_is_script_cached') && opcache_is_script_cached($file)) {
+			require $file; // not atomic, any idea?
+			return;
+		}
+
+		$handle = fopen($file, 'c+');
 		if (!$handle) {
 			throw new Nette\IOException("Unable to open or create file '$file'.");
 		}


### PR DESCRIPTION
Bored at school I got an idea to avoid touching disk for PHP 5.5.11+. It relies on undocumented function opcache_is_script_cached (http://stackoverflow.com/questions/23229849/opcache-is-script-cached-function-in-php5-5-11).

Not sure how to solve the atomicity. We may use `@include` and check return value for `FALSE`.
