### PR TITLE
ContainerBuilder: Add support for aliasing service definitions

### DIFF
--- a/src/DI/Container.php
+++ b/src/DI/Container.php
@@ -20,6 +20,7 @@ class Container extends Nette\Object
 	const TAGS = 'tags';
 	const TYPES = 'types';
 	const SERVICES = 'services';
+	const ALIASES = 'aliases';
 
 	/** @var array  user parameters */
 	/*private*/public $parameters = array();
@@ -60,7 +61,9 @@ class Container extends Nette\Object
 		if (!is_string($name) || !$name) {
 			throw new Nette\InvalidArgumentException(sprintf('Service name must be a non-empty string, %s given.', gettype($name)));
 
-		} elseif (isset($this->registry[$name])) {
+		}
+		$name = isset($this->meta[self::ALIASES][$name]) ? $this->meta[self::ALIASES][$name] : $name;
+		if (isset($this->registry[$name])) {
 			throw new Nette\InvalidStateException("Service '$name' already exists.");
 
 		} elseif (!is_object($service)) {
@@ -82,6 +85,7 @@ class Container extends Nette\Object
 	 */
 	public function removeService($name)
 	{
+		$name = isset($this->meta[self::ALIASES][$name]) ? $this->meta[self::ALIASES][$name] : $name;
 		unset($this->registry[$name]);
 	}
 
@@ -94,6 +98,7 @@ class Container extends Nette\Object
 	 */
 	public function getService($name)
 	{
+		$name = isset($this->meta[self::ALIASES][$name]) ? $this->meta[self::ALIASES][$name] : $name;
 		if (!isset($this->registry[$name])) {
 			$this->registry[$name] = $this->createService($name);
 		}
@@ -108,6 +113,7 @@ class Container extends Nette\Object
 	 */
 	public function hasService($name)
 	{
+		$name = isset($this->meta[self::ALIASES][$name]) ? $this->meta[self::ALIASES][$name] : $name;
 		return isset($this->registry[$name])
 			|| method_exists($this, $method = Container::getMethodName($name)) && $this->getReflection()->getMethod($method)->getName() === $method;
 	}
@@ -123,6 +129,7 @@ class Container extends Nette\Object
 		if (!$this->hasService($name)) {
 			throw new MissingServiceException("Service '$name' not found.");
 		}
+		$name = isset($this->meta[self::ALIASES][$name]) ? $this->meta[self::ALIASES][$name] : $name;
 		return isset($this->registry[$name]);
 	}
 
@@ -135,6 +142,7 @@ class Container extends Nette\Object
 	 */
 	public function createService($name, array $args = array())
 	{
+		$name = isset($this->meta[self::ALIASES][$name]) ? $this->meta[self::ALIASES][$name] : $name;
 		$method = Container::getMethodName($name);
 		if (isset($this->creating[$name])) {
 			throw new Nette\InvalidStateException(sprintf('Circular reference detected for services: %s.', implode(', ', array_keys($this->creating))));

--- a/tests/DI/Compiler.services.tags.phpt
+++ b/tests/DI/Compiler.services.tags.phpt
@@ -38,6 +38,7 @@ Assert::same(array(
 		'b' => array('lorem' => 'c'),
 		'd' => array('lorem' => array('e')),
 	),
+	'aliases' => array(),
 ), $prop->getValue($container) );
 
 Assert::same( array('lorem' => TRUE), $container->findByTag('a') );

--- a/tests/DI/ContainerBuilder.aliases2.phpt
+++ b/tests/DI/ContainerBuilder.aliases2.phpt
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Test: Nette\DI\ContainerBuilder and aliases.
+ */
+
+use Nette\DI,
+	Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+class Service
+{}
+
+interface ServiceFactory
+{
+	function create();
+}
+
+interface ServiceFactory2
+{
+	function create();
+}
+
+$builder = new DI\ContainerBuilder;
+
+$builder->addDefinition('serviceFactory')
+	->setImplement('ServiceFactory')
+	->setFactory('@service');
+
+$builder->addDefinition('serviceFactoryViaClass')
+	->setImplement('ServiceFactory2')
+	->setFactory('@\Service');
+
+$builder->addDefinition('service')
+	->setClass('Foo');
+
+
+$builder->addAlias('aliased.service', 'service');
+$builder->addAlias('aliased.serviceFactory', 'serviceFactory');
+$builder->addAlias('aliased.serviceFactoryViaClass', 'serviceFactoryViaClass');
+
+// Access to service definition using alias
+Assert::true( $builder->hasDefinition('aliased.service') );
+Assert::same( $builder->getDefinition('service'), $builder->getDefinition('aliased.service'));
+
+// Replace service definition using alias
+$builder->removeDefinition( 'aliased.service' );
+Assert::false( $builder->hasDefinition('aliased.service') );
+$builder->addDefinition('aliased.service')
+	->setClass('Service');
+
+
+$container = createContainer($builder);
+
+Assert::type( 'Service', $container->getService('service') );
+Assert::type( 'Service', $container->getService('aliased.service') );
+Assert::same( $container->getService('service'), $container->getService('aliased.service') );
+
+Assert::type( 'ServiceFactory', $container->getService('serviceFactory') );
+Assert::type( 'ServiceFactory', $container->getService('aliased.serviceFactory') );
+
+Assert::type( 'ServiceFactory2', $container->getService('aliased.serviceFactoryViaClass') );
+Assert::type( 'ServiceFactory2', $container->getService('serviceFactoryViaClass') );
+
+// autowiring test
+Assert::type( 'Service', $container->getByType('Service') );
+Assert::type( 'ServiceFactory', $container->getByType('ServiceFactory') );
+Assert::type( 'ServiceFactory2', $container->getByType('ServiceFactory2') );


### PR DESCRIPTION
At the moment there is no sensible way how to rename a service without massive BC break, that's why some of the "Nette" services use prefixes, some not etc. This PR tries to fix this by adding support for service aliases to `ContainerBuilder`.
Open question is whether or not to automatically trigger deprecation warning when the old name (=alias) is used instead of the new one.