### PR TITLE
Compiler: re-adding extension appends it to the end of the list.

### DIFF
--- a/src/DI/Compiler.php
+++ b/src/DI/Compiler.php
@@ -50,6 +50,7 @@ class Compiler extends Nette\Object
 		if (isset(self::$reserved[$name])) {
 			throw new Nette\InvalidArgumentException("Name '$name' is reserved.");
 		}
+		unset($this->extensions[$name]);
 		$this->extensions[$name] = $extension->setCompiler($this, $name);
 		return $this;
 	}

--- a/tests/DI/Compiler.addExtension.phpt
+++ b/tests/DI/Compiler.addExtension.phpt
@@ -57,8 +57,9 @@ class ProcessingCompiler extends Nette\DI\Compiler
 
 $compiler = new ProcessingCompiler;
 
-$compiler->addExtension('foo', new FooExtension());
 $compiler->addExtension('baz', new BazExtension());
+$compiler->addExtension('foo', new FooExtension());
+$compiler->addExtension('baz', new BazExtension()); // re-register baz extension
 $extensions = $compiler->getExtensions();
 
 Assert::same(2, count($extensions));


### PR DESCRIPTION
This is an attempt to solve problem of extension dependencies, see http://forum.nette.org/en/21383-extension-dependencies-feedback for more details.
Thanks to #30 core Nette extensions can now be (re-)added using `ExtensionsExtension`. So to solve the problem mentioned in the forum you would use configuration something like:

```
extensions:
    presenters: Kdyby\PresentersLocator\DI\PresentersLocatorExtension
    inject: Nette\DI\Extensions\InjectExtension
```

Or possibly `PresentersLocatorExtension` could re-add `InjectExtenion` in its `loadConfiguration` method.
