### PR TITLE
[FAILING TEST ] ContainerBuilder: interface as a service factory

### DIFF
--- a/tests/DI/ContainerBuilder.byClass.phpt
+++ b/tests/DI/ContainerBuilder.byClass.phpt
@@ -23,7 +23,15 @@ class Factory
 
 }
 
-class AnnotatedFactory
+
+interface IFactory
+{
+
+	function create();
+
+}
+
+class AnnotatedFactory implements IFactory
 {
 	public $methods;
 
@@ -59,6 +67,11 @@ $builder->addDefinition('four')
 	->setAutowired(FALSE)
 	->setFactory('@\AnnotatedFactory::create');
 
+$builder->addDefinition('five')
+	->setAutowired(FALSE)
+	->setFactory('@\IFactory::create');
+
+
 
 $container = createContainer($builder);
 
@@ -85,3 +98,6 @@ Assert::type( 'stdClass', $container->getService('four') );
 Assert::same(array(
 	array('create', array()),
 ), $annotatedFactory->methods);
+
+
+Assert::type( 'stdClass', $container->getService('five') );


### PR DESCRIPTION
```
Nette\DI\ServiceCreationException: Factory '\IFactory::create' used in service 'five' is not callable.
```
The error was introduced by 3359e540a

Problem is, that interface method is not callable..