### PR TITLE
Compiler: aliases for nette config section

### DIFF
--- a/src/DI/Compiler.php
+++ b/src/DI/Compiler.php
@@ -112,6 +112,15 @@ class Compiler extends Nette\Object
 	{
 		for ($i = 0; $slice = array_slice($this->extensions, $i, 1, TRUE); $i++) {
 			$name = key($slice);
+
+			if (isset($this->config['nette'][$name]) && is_array($this->config['nette'][$name])) {
+				if (isset($this->config[$name])) {
+					throw new Nette\DeprecatedException("Configuration section 'nette.$name' is deprecated, move it to section '$name'.");
+				}
+				$this->config[$name] = $this->config['nette'][$name];
+				unset($this->config['nette'][$name]);
+			}
+
 			if (isset($this->config[$name])) {
 				$this->config[$name] = $tmp = $this->builder->expand($this->config[$name]);
 				unset($tmp['services']);

--- a/tests/DI/Compiler.aliasNetteConfig.phpt
+++ b/tests/DI/Compiler.aliasNetteConfig.phpt
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * Test: Nette\DI\Compiler alias for nette config
+ */
+
+use Nette\DI,
+	Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+class TestExtension extends Nette\DI\CompilerExtension
+{
+}
+
+
+test(function() {
+	$compiler = new DI\Compiler;
+	$compiler->addExtension('nette', new TestExtension);
+	$compiler->addExtension('test', $extension = new TestExtension);
+	$container = createContainer($compiler, '
+	nette:
+		test:
+			item: 10
+	');
+
+	Assert::same(array('item' => 10), $extension->getConfig());
+});
+
+
+test(function() {
+	$compiler = new DI\Compiler;
+	$compiler->addExtension('nette', new TestExtension);
+	$compiler->addExtension('test', $extension = new TestExtension);
+	$container = createContainer($compiler, '
+	nette:
+		test: 10
+
+	test:
+		item: 20
+	');
+
+	Assert::same(array('item' => 20), $extension->getConfig());
+});
+
+
+Assert::exception(function() {
+	$compiler = new DI\Compiler;
+	$compiler->addExtension('nette', new TestExtension);
+	$compiler->addExtension('test', $extension = new TestExtension);
+	$container = createContainer($compiler, '
+	nette:
+		test:
+			item: 10
+
+	test:
+		item: 20
+	');
+}, 'Nette\DeprecatedException', "Configuration section 'nette.test' is deprecated, move it to section 'test'.");


### PR DESCRIPTION
This is hardcoded hack for nette/bootstrap#4, which makes every new extension much more readable and usable.

