### PR TITLE
CompilerExtension::validateConfig() returns combined array

### DIFF
--- a/src/DI/CompilerExtension.php
+++ b/src/DI/CompilerExtension.php
@@ -46,12 +46,14 @@ abstract class CompilerExtension extends Nette\Object
 
 	/**
 	 * Returns extension configuration.
-	 * @param  array default unexpanded values.
 	 * @return array
 	 */
-	public function getConfig(array $defaults = NULL)
+	public function getConfig()
 	{
-		return Config\Helpers::merge($this->config, $this->getContainerBuilder()->expand($defaults));
+		if (func_num_args()) { // deprecated
+			return Config\Helpers::merge($this->config, $this->getContainerBuilder()->expand(func_get_arg(0)));
+		}
+		return $this->config;
 	}
 
 

--- a/src/DI/CompilerExtension.php
+++ b/src/DI/CompilerExtension.php
@@ -58,6 +58,25 @@ abstract class CompilerExtension extends Nette\Object
 
 
 	/**
+	 * Checks whether $config contains only $expected items and returns combined array.
+	 * @return array
+	 * @throws Nette\InvalidStateException
+	 */
+	public function validateConfig(array $expected, array $config = NULL, $name = NULL)
+	{
+		if (func_num_args() === 1) {
+			return $this->config = $this->validateConfig($expected, $this->config);
+		}
+		if ($extra = array_diff_key((array) $config, $expected)) {
+			$name = $name ?: $this->name;
+			$extra = implode(", $name.", array_keys($extra));
+			throw new Nette\InvalidStateException("Unknown configuration option $name.$extra.");
+		}
+		return Config\Helpers::merge($config, $expected);
+	}
+
+
+	/**
 	 * @return ContainerBuilder
 	 */
 	public function getContainerBuilder()
@@ -119,19 +138,4 @@ abstract class CompilerExtension extends Nette\Object
 	{
 	}
 
-
-	/**
-	 * Checks whether $config contains only $expected items.
-	 * @return void
-	 * @throws Nette\InvalidStateException
-	 */
-	protected function validateConfig(array $expected, array $config = NULL, $name = NULL)
-	{
-		if ($extra = array_diff_key(func_num_args() > 1 ? (array) $config : $this->config, $expected)) {
-			$name = $name ?: $this->name;
-			$extra = implode(", $name.", array_keys($extra));
-			throw new Nette\InvalidStateException("Unknown configuration option $name.$extra.");
 		}
-	}
-
-}

--- a/src/DI/Extensions/DecoratorExtension.php
+++ b/src/DI/Extensions/DecoratorExtension.php
@@ -28,9 +28,7 @@ class DecoratorExtension extends Nette\DI\CompilerExtension
 	public function beforeCompile()
 	{
 		foreach ($this->getConfig() as $class => $info) {
-			$info = (array) $info;
-			$this->validateConfig($this->defaults, $info, $this->prefix($class));
-			$info += $this->defaults;
+			$info = $this->validateConfig($this->defaults, $info, $this->prefix($class));
 			if ($info['inject'] !== NULL) {
 				$info['tags'][InjectExtension::TAG_INJECT] = $info['inject'];
 			}

--- a/tests/DI/CompilerExtension.validateConfig.phpt
+++ b/tests/DI/CompilerExtension.validateConfig.phpt
@@ -18,26 +18,45 @@ class MyExtension extends Nette\DI\CompilerExtension
 }
 
 
-Assert::with(new MyExtension, function() {
-	$this->validateConfig(array());
-	$this->validateConfig(array('a' => TRUE, 'b' => TRUE), array('a' => TRUE));
+test(function() {
+	$ext = new MyExtension;
+	Assert::same(array(), $ext->validateConfig(array()));
+	Assert::same(array('a' => 2, 'b' => 1), $ext->validateConfig(array('a' => 1, 'b' => 1), array('a' => 2)));
+});
+
+test(function() {
+	$ext = new MyExtension;
+	$ext->setConfig(array('a' => 2));
+	Assert::same(array('a' => 2, 'b' => 1), $ext->validateConfig(array('a' => 1, 'b' => 1)));
+	Assert::same(array('a' => 2, 'b' => 1), $ext->getConfig());
+});
+
+test(function() {
+	$ext = new MyExtension;
+	$ext->setConfig(array('a' => 2));
+	Assert::same(array('a' => 3, 'b' => 1), $ext->validateConfig(array('a' => 1, 'b' => 1), array('a' => 3)));
+	Assert::same(array('a' => 2), $ext->getConfig());
+});
+
+test(function() {
+	$ext = new MyExtension;
+	$ext->setConfig(array('a' => 2));
+	Assert::same(array('a' => 1, 'b' => 1), $ext->validateConfig(array('a' => 1, 'b' => 1), NULL));
+	Assert::same(array('a' => 2), $ext->getConfig());
 });
 
 Assert::exception(function() {
-	Assert::with(new MyExtension, function() {
-		$this->validateConfig(array('a' => TRUE, 'b' => TRUE), array('c' => TRUE));
-	});
+	$ext = new MyExtension;
+	$ext->validateConfig(array('a' => 1, 'b' => 1), array('c' => 1));
 }, 'Nette\InvalidStateException', 'Unknown configuration option my.c.');
 
 Assert::exception(function() {
-	Assert::with(new MyExtension, function() {
-		$this->validateConfig(array('a' => TRUE, 'b' => TRUE), array('c' => TRUE, 'd' => TRUE), 'name');
-	});
+	$ext = new MyExtension;
+	$ext->validateConfig(array('a' => 1, 'b' => 1), array('c' => 1, 'd' => 1), 'name');
 }, 'Nette\InvalidStateException', 'Unknown configuration option name.c, name.d.');
 
 Assert::exception(function() {
-	Assert::with(new MyExtension, function() {
-		$this->setConfig(array('c' => TRUE, 'd' => TRUE));
-		$this->validateConfig(array('a' => TRUE, 'b' => TRUE));
-	});
+	$ext = new MyExtension;
+	$ext->setConfig(array('c' => 1, 'd' => 1));
+	$ext->validateConfig(array('a' => 1, 'b' => 1));
 }, 'Nette\InvalidStateException', 'Unknown configuration option my.c, my.d.');


### PR DESCRIPTION
I have a problem with validateConfig() usage, it is not understandable. Typical usecase is:

```php
$config = $this->getConfig($this->defaults);
$this->validateConfig($this->defaults, $config);
```

In this case `$config` is unnecessary, so you can write: 

```php
$config = $this->getConfig($this->defaults);
$this->validateConfig($this->defaults);
```

It seems like WTF. Defaults are passed to `validateConfig` for the same reasons as to `getConfig()`, but it is really weirg. 

What about this simplification?

```php
$config = $this->validateConfig($this->defaults);
```

Or

```php
$config = $this->getValidatedConfig($this->defaults);
```


