### PR TITLE
ContainerBuilder: implement escaping of '@' at the beginning of string

### DIFF
--- a/src/DI/ContainerBuilder.php
+++ b/src/DI/ContainerBuilder.php
@@ -718,7 +718,13 @@ class ContainerBuilder extends Nette\Object
 				$val = '@' . current(array_keys($that->getDefinitions(), $val, TRUE));
 			}
 
-			if (is_string($val) && substr($val, 0, 1) === '@') {
+			if (!is_string($val)) {
+				return;
+
+			} elseif (substr($val, 0, 2) === '@@') {
+				$val = substr($val, 1);
+
+			} elseif (substr($val, 0, 1) === '@') {
 				$pair = explode('::', $val, 2);
 				$name = $that->getServiceName($pair[0]);
 				if (isset($pair[1]) && preg_match('#^[A-Z][A-Z0-9_]*\z#', $pair[1], $m)) {

--- a/tests/DI/ContainerBuilder.basic.phpt
+++ b/tests/DI/ContainerBuilder.basic.phpt
@@ -21,7 +21,7 @@ class Service
 		return new self(array_slice(func_get_args(), 1));
 	}
 
-	function __construct()
+	function __construct($arg = null)
 	{
 		$this->methods[] = array(__FUNCTION__, func_get_args());
 	}
@@ -36,7 +36,7 @@ class Service
 
 $builder = new DI\ContainerBuilder;
 $builder->addDefinition('one')
-	->setClass('Service');
+	->setClass('Service', array('@@string'));
 $builder->addDefinition('three')
 	->setClass('Service', array('a', 'b'));
 
@@ -67,7 +67,7 @@ Assert::false( $container->hasService('One') );
 Assert::false( $container->hasService('oNe') );
 
 Assert::same( array(
-	array('__construct', array())
+	array('__construct', array('@string'))
 ), $container->getService('one')->methods );
 
 Assert::type( 'Service', $container->getService('three') );


### PR DESCRIPTION
Attempt to solve nette/nette#1279

`ContainerBuilder:.formatPhp()` recognizes '\@' at the beginning of string value as escaped '@'.

What do you think about this, is this a reasonable approach? Shall I go ahead and write tests for it?