### PR TITLE
Compiler: extension without parameters is allowed now

### DIFF
--- a/src/DI/Compiler.php
+++ b/src/DI/Compiler.php
@@ -173,7 +173,7 @@ class Compiler extends Nette\Object
 			if (isset($this->config[$name]['services'])) {
 				trigger_error("Support for inner section 'services' inside extension was removed (used in '$name').", E_USER_DEPRECATED);
 			}
-			$extension->setConfig($this->config[$name]);
+			$extension->setConfig($this->config[$name] ?: array());
 		}
 
 		foreach ($extensions as $extension) {

--- a/tests/DI/Compiler.extension.phpt
+++ b/tests/DI/Compiler.extension.phpt
@@ -31,10 +31,15 @@ class DatabaseExtension extends Nette\DI\CompilerExtension
 	}
 }
 
+class FooExtension extends Nette\DI\CompilerExtension
+{
+}
+
 
 $compiler = new DI\Compiler;
 $extension = new DatabaseExtension;
 $compiler->addExtension('database', $extension);
+$compiler->addExtension('foo', new FooExtension);
 $container = createContainer($compiler, '
 parameters:
 	bar: hello
@@ -42,6 +47,8 @@ parameters:
 
 database:
 	foo: %bar%
+
+foo:
 ');
 
 


### PR DESCRIPTION
Pro předpřipravenou strukturu configu jsou často potřebné prázdné sekce (security, atd..), které nastavujete až v průběhu vývoje. V nette 2.2.x to bylo možné.