### PR TITLE
Compiler: simplified syntax of arguments for generated factories (BC break)

### DIFF
--- a/src/DI/Compiler.php
+++ b/src/DI/Compiler.php
@@ -303,7 +303,11 @@ class Compiler extends Nette\Object
 			$config = array('class' => NULL, 'implement' => $config);
 
 		} elseif ($config instanceof Statement && is_string($config->getEntity()) && interface_exists($config->getEntity())) {
-			$config = array('class' => NULL, 'implement' => $config->getEntity(), 'factory' => array_shift($config->arguments));
+			if (method_exists($config->getEntity(), 'create')) {
+				$config = array('class' => NULL, 'implement' => $config->getEntity(), 'arguments' => $config->arguments);
+			} else {
+				$config = array('class' => NULL, 'implement' => $config->getEntity(), 'factory' => array_shift($config->arguments));
+			}
 
 		} elseif (!is_array($config) || isset($config[0], $config[1])) {
 			$config = array('class' => NULL, 'create' => $config);

--- a/tests/DI/files/compiler.generatedFactory.neon
+++ b/tests/DI/files/compiler.generatedFactory.neon
@@ -3,7 +3,9 @@ services:
 	bar: Bar
 	baz: Baz
 
-	lorem: \ILoremFactory(Lorem)
+	lorem:
+		implement: ILoremFactory
+		class: Lorem
 
 	finder: IFinderFactory
 
@@ -28,6 +30,4 @@ services:
 
 	fooFactory4: IFooFactory
 
-	factory5:
-		implement: ITestClassFactory
-		arguments: ['foo']
+	factory5: ITestClassFactory('foo')


### PR DESCRIPTION
Not ready for merge, I'd like to discuss the BC break first.

When I create components using generated factories, I often need to pass some parameters to the component in config. This is done using this syntax + return annotation in the interface:

``` yml
services:
    -
        implement: IMyComponentFactory
        arguments: [%parameter%]
```

I'd like to simplify it to this:

``` yml
services:
    - IMyComponentFactory(%parameter%)
```

It is a BC break though because of [this commit](https://github.com/nette/di/commit/db2fab709e147b83ae5d70f18e8529076e34b649). For that reason I never suggested this change, even though I thought it was more consistent to use the syntax for arguments than the returned class name. Recently we have discussed the matter [here](http://www.zeminem.cz/generovane-tovarnicky-definitive-guide#comment-1927498010) (czech only) which convinced me that I'm not the only one with the same thought so I'd like to know opinions of more people.

As for the BC break, for now we could add a condition using `class_exists` and throw E_USER_WARNING error. That means the new syntax would be somewhat limited for now because strings that are classes would not be passable like this (or at least not when passing just one argument).

What do you think?
