### PR TITLE
ContainerBuilder: removeDefinition removes from classes too

### DIFF
--- a/src/DI/ContainerBuilder.php
+++ b/src/DI/ContainerBuilder.php
@@ -78,7 +78,19 @@ class ContainerBuilder extends Nette\Object
 	public function removeDefinition($name)
 	{
 		$name = isset($this->aliases[$name]) ? $this->aliases[$name] : $name;
-		unset($this->definitions[$name]);
+
+		if (isset($this->definitions[$name])) {
+			$class = $this->definitions[$name]->getClass();
+			if (isset($this->classes[$class][TRUE])) {
+				foreach ($this->classes[$class][TRUE] as $key => $definitionName) {
+					if ($name === $definitionName) {
+						unset($this->classes[$class][TRUE][$key]);
+					}
+				}
+			}
+
+			unset($this->definitions[$name]);
+		}
 	}
 
 

--- a/src/DI/ContainerBuilder.php
+++ b/src/DI/ContainerBuilder.php
@@ -80,13 +80,16 @@ class ContainerBuilder extends Nette\Object
 		$name = isset($this->aliases[$name]) ? $this->aliases[$name] : $name;
 
 		if (isset($this->definitions[$name])) {
-			$class = $this->definitions[$name]->getClass();
-			$this->removeClassFromReference($name, $class);
-
-			$reflectionClass = new ReflectionClass($class);
-			while ($parentClass = $reflectionClass->getParentClass()) {
-				$this->removeClassFromReference($name, $parentClass->getName());
-				$reflectionClass = new ReflectionClass($parentClass->getName());
+			if ($this->classes) {
+				foreach ($this->classes as $class => $tmp) {
+					foreach ($tmp as $mode => $serviceNames) {
+						foreach ($serviceNames as $key => $serviceName) {
+							if ($name === $serviceName) {
+								unset($this->classes[$class][$mode][$key]);
+							}
+						}
+					}
+				}
 			}
 
 			unset($this->definitions[$name]);

--- a/tests/DI/Compiler.inheritance.phpt
+++ b/tests/DI/Compiler.inheritance.phpt
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Test: Nette\DI\Compiler: multiple service inhertance
+ * Test: Nette\DI\Compiler: multiple service inheritance
  * @package    Nette\DI
  */
 

--- a/tests/DI/ContainerBuilder.removeDefinition.phpt
+++ b/tests/DI/ContainerBuilder.removeDefinition.phpt
@@ -11,6 +11,11 @@ use Nette\DI,
 require __DIR__ . '/../bootstrap.php';
 
 
+class B extends stdClass {}
+
+class A extends B {}
+
+
 $builder = new DI\ContainerBuilder;
 
 $builder->addDefinition('one')
@@ -19,13 +24,30 @@ $builder->addDefinition('one')
 $builder->addDefinition('two')
 	->setClass('stdClass');
 
+$builder->addDefinition('three')
+	->setClass('stdClass')
+	->setAutowired(FALSE);
+
+$builder->addDefinition('four')
+	->setClass('B');
+
 $builder->prepareClassList();
 
 Assert::exception(function () use ($builder) {
 	$builder->getByType('stdClass');
-}, 'Nette\DI\ServiceCreationException', 'Multiple services of type stdClass found: one, two');
+}, 'Nette\DI\ServiceCreationException', 'Multiple services of type stdClass found: one, two, four');
+
+Assert::count( 4, $builder->findByType('stdClass') );
 
 
 $builder->removeDefinition('two');
+$builder->removeDefinition('four');
 
 Assert::same( 'one', $builder->getByType('stdClass') );
+
+Assert::count( 2, $builder->findByType('stdClass') );
+
+
+$builder->removeDefinition('three');
+
+Assert::count( 1, $builder->findByType('stdClass') );

--- a/tests/DI/ContainerBuilder.removeDefinition.phpt
+++ b/tests/DI/ContainerBuilder.removeDefinition.phpt
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Test: Nette\DI\ContainerBuilder and removeDefinition.
+ */
+
+use Nette\DI,
+	Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+$builder = new DI\ContainerBuilder;
+
+$builder->addDefinition('one')
+	->setClass('stdClass');
+
+$builder->addDefinition('two')
+	->setClass('stdClass');
+
+$builder->prepareClassList();
+
+Assert::exception(function () use ($builder) {
+	$builder->getByType('stdClass');
+}, 'Nette\DI\ServiceCreationException', 'Multiple services of type stdClass found: one, two');
+
+
+$builder->removeDefinition('two');
+
+Assert::same( 'one', $builder->getByType('stdClass') );

--- a/tests/DI/ContainerBuilder.removeDefinition.phpt
+++ b/tests/DI/ContainerBuilder.removeDefinition.phpt
@@ -11,9 +11,11 @@ use Nette\DI,
 require __DIR__ . '/../bootstrap.php';
 
 
-class B extends stdClass {}
+class B extends stdClass
+{}
 
-class A extends B {}
+class A extends B
+{}
 
 
 $builder = new DI\ContainerBuilder;
@@ -29,7 +31,7 @@ $builder->addDefinition('three')
 	->setAutowired(FALSE);
 
 $builder->addDefinition('four')
-	->setClass('B');
+	->setClass('A');
 
 $builder->prepareClassList();
 


### PR DESCRIPTION
Use case:

```php
$containerBuilder->addDefintion('one')->setClass('stdClass');
$containerBuilder->addDefintion('two')->setClass('stdClass');
$containerBuilder->removeDefinition('two');
$containerBuilder->getByType('stdClass'); // breaks, because reference to 'two' is still saved under 'stdClass'
```