### PR TITLE
removeDefinition fix for removing first added one

### DIFF
--- a/src/DI/ContainerBuilder.php
+++ b/src/DI/ContainerBuilder.php
@@ -204,7 +204,7 @@ class ContainerBuilder extends Nette\Object
 			return;
 
 		} elseif (count($this->classes[$class][TRUE]) === 1) {
-			return $this->classes[$class][TRUE][0];
+			return reset($this->classes[$class][TRUE]);
 
 		} else {
 			throw new ServiceCreationException("Multiple services of type $class found: " . implode(', ', $this->classes[$class][TRUE]));

--- a/tests/DI/ContainerBuilder.removeDefinition.phpt
+++ b/tests/DI/ContainerBuilder.removeDefinition.phpt
@@ -42,10 +42,10 @@ Assert::exception(function () use ($builder) {
 Assert::count( 4, $builder->findByType('stdClass') );
 
 
-$builder->removeDefinition('two');
+$builder->removeDefinition('one');
 $builder->removeDefinition('four');
 
-Assert::same( 'one', $builder->getByType('stdClass') );
+Assert::same( 'two', $builder->getByType('stdClass') );
 
 Assert::count( 2, $builder->findByType('stdClass') );
 


### PR DESCRIPTION
One more related bug to #71:

```php
$someInterface => [
    0 => FirstService
    1 => SecondService
];
```

Remove 'FirstService':


```php
$someInterface => [
    1 => SecondService
];
```

[Then, `getByType` will try to get [0]](https://github.com/nette/di/blob/72bc3f0ade6d9c8f0e302e87466cd5c291ffac24/src/DI/ContainerBuilder.php#L207) => FAIL

Solution? Something like:

```php
return reset($this->classes[$class][TRUE]);
```

What do you think?