### PR TITLE
 Added tokenizer module for testing under unix

### DIFF
--- a/tests/php-unix.ini
+++ b/tests/php-unix.ini
@@ -1,5 +1,6 @@
 [PHP]
 ;extension_dir = "./ext"
+extension=tokenizer.so
 
 [Zend]
 ;zend_extension="./ext/zend_extension"


### PR DESCRIPTION
php-unix.ini: added tokenizer extension
Tokenizer is needed under default OpenSuSE installation of Apache 2