### PR TITLE
Xml adapter

### DIFF
--- a/src/DI/Config/Adapters/XmlAdapter.php
+++ b/src/DI/Config/Adapters/XmlAdapter.php
@@ -1,0 +1,427 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (http://nette.org)
+ * Copyright (c) 2015 Petr Bilek (http://ww.sallyx.org)
+ */
+
+namespace Nette\DI\Config\Adapters;
+
+use Nette;
+use Nette\DI\Config\Helpers;
+use Nette\DI\Statement;
+
+/**
+ * Reading and generating XML files.
+ */
+class XmlAdapter extends Nette\Object implements Nette\DI\Config\IAdapter
+{
+
+	const NS = "http://www.nette.org/xmlns/nette/config/1.0";
+
+	/**
+	 * Reads configuration from XML file.
+	 * @param  string  file name
+	 * @return array
+	 */
+	public function load($file)
+	{
+		$opt = LIBXML_NOBLANKS | LIBXML_NOCDATA | LIBXML_NOENT | LIBXML_NSCLEAN; // | LIBXML_PEDANTIC ?
+		$parserClass = "\\Nette\\DI\\Config\\Adapters\\XMLElementParser";
+		$doc = simplexml_load_file($file, $parserClass, $opt, self::NS);
+		return $doc->parse();
+	}
+
+	/**
+	 * Generates configuration in XML format.
+	 * @return string
+	 */
+	public function dump(array $data)
+	{
+		$writter = new XmlElementWritter('<config/>', 0, false, self::NS, "nc");
+		$writter->addAttribute('xmlns:xmlns:nc', self::NS);
+		$writter->addAttribute('xmlns', self::NS);
+		$writter->addConfig($data);
+		return $writter->asXML();
+	}
+
+}
+
+/**
+ * This class helps to parse XML config to PHP array
+ * @internal
+ */
+class XMLElementParser extends \SimpleXMLElement
+{
+
+	/** Names of attributes */
+	const ATTR_ARRAY = 'array',
+		ATTR_BOOL = 'bool',
+		ATTR_NUMBER = 'number',
+		ATTR_DELIMITER = 'delimiter',
+		ATTR_EXTENDS = 'extends',
+		ATTR_MERGING = 'merging',
+		ATTR_NULL = 'null',
+		ATTR_STATEMENT = 'statement',
+		ATTR_SPACE = 'space';
+
+	/** Values of attributes */
+	const ATTR_MERGING_REPLACE = 'replace',
+		ATTR_ARRAY_ASSOCIATIVE = 'associative',
+		ATTR_ARRAY_NUMERIC = 'numeric',
+		ATTR_ARRAY_STRING = 'string',
+		ATTR_NULL_VALUE = 'null',
+		ATTR_SPACE_PRESERVE = 'preserve',
+		DEFAULT_DELIMITER = ',';
+
+	/**
+	 * Parse DI config
+	 *
+	 * @return array|string|NULL|Statement
+	 */
+	public function parse()
+	{
+		$statement = $this->getAttribute(self::ATTR_STATEMENT);
+		if (!empty($statement)) {
+			if ($statement === self::ATTR_STATEMENT) {
+				return $this->parseStatements($statement);
+			}
+			$res = $this->getNeonAdapter()->load('data://text/plain,- ' . $statement);
+			return array_shift($res);
+		}
+
+		$res = $this->parseChildren();
+		$extends = $this->getAttribute(self::ATTR_EXTENDS);
+		$merging = $this->getattribute(self::ATTR_MERGING);
+		if ($merging === self::ATTR_MERGING_REPLACE && !is_array($res)) {
+			$name = $this->getName();
+			throw new Nette\InvalidStateException("Replacing operator is available only for arrays, element '$name' is not array");
+		}
+		if (!empty($extends)) {
+			$res[Helpers::EXTENDS_KEY] = $extends;
+		} elseif ($merging === self::ATTR_MERGING_REPLACE) {
+			$res[Helpers::EXTENDS_KEY] = Helpers::OVERWRITE;
+		}
+		return $res;
+	}
+
+	/**
+	 * Returns element value
+	 *
+	 * If element has a bool attribute, returns bool value of this attribute.
+	 * If element has a null attribute, returns NULL;
+	 * Othervise returns string value of this element.
+	 *
+	 * @return string|bool|NULL
+	 */
+	public function getValue()
+	{
+		if ($this->getAttribute(self::ATTR_NULL)) {
+			return NULL;
+		}
+		$bool = $this->getAttribute(self::ATTR_BOOL);
+		if ($bool) {
+			switch (strtolower($bool)) {
+				case 'yes':
+// break intentionally omitted
+				case 'true':
+// break intentionally omitted
+				case 'on':
+// break intentionally omitted
+				case '1':
+					return TRUE;
+				default:
+					return FALSE;
+			}
+		}
+		$number = $this->getAttribute(self::ATTR_NUMBER);
+		if (!is_null($number)) {
+			return $number + 0;
+		}
+		return (string) $this;
+	}
+
+	/**
+	 * Returns attribute of name $name if exists, or $default value
+	 *
+	 * @param string $name
+	 * @param string $default
+	 * @return string|NULL
+	 */
+	public function getAttribute($name, $default = NULL)
+	{
+		$attrs = $this->attributes();
+		$attr = $attrs[$name];
+		if (is_null($attr)) {
+			return $default;
+		}
+		return (string) $attr;
+	}
+
+	/**
+	 * @staticvar type $neonAdapter
+	 * @return type
+	 */
+	private function getNeonAdapter()
+	{
+		static $neonAdapter;
+		$neonAdapter = $neonAdapter ? : new NeonAdapter();
+		return $neonAdapter;
+	}
+
+	/**
+	 * Parse element with attribute statement (list of statements)
+	 *
+	 * @param string $statements
+	 * @return Statement
+	 */
+	private function parseStatements($statements)
+	{
+		$res = null;
+		foreach ($this->children() as $statement) {
+			list($entity, $arguments) = $this->parseStatement($statement);
+			if (!$res) {
+				$res = new Statement($entity, $arguments);
+			} else {
+				$res = new Statement(array($res, $entity), $arguments);
+			}
+		}
+
+		return $res;
+	}
+
+	/**
+	 * Parse one statement from statement list
+	 * @param \SimpleXmlElement $child
+	 * @return array  [0 => $entity, 1 => $attributes]
+	 */
+	private function parseStatement($child)
+	{
+		$entityElement = $child->ent;
+		if (empty($entityElement)) {
+			throw new \Nette\InvalidStateException("Expected <ent> element in statement " . $this->asXML());
+		}
+		$entity = $child->ent->getValue();
+		if (!is_string($entity) or $entity === '') {
+			throw new \Nette\InvalidStateException("Element <ent> must have a non-empty string value.");
+		}
+
+		$argsElement = $child->args;
+		if (empty($argsElement)) {
+			return array($entity, NULL);
+		}
+		$arrayAttr = $argsElement[0]->getAttribute(self::ATTR_ARRAY);
+		if (is_null($arrayAttr)) {
+			$argsElement[0]->addAttribute(self::ATTR_ARRAY, self::ATTR_ARRAY_NUMERIC);
+		}
+
+		$attributes = $argsElement[0]->parseChildren();
+		if (!is_array($attributes)) {
+			$attributes = array($attributes);
+		}
+		return array($entity, $attributes);
+	}
+
+	/**
+	 * Parse children elements or value of this element
+	 *
+	 * @return array|string|NULL|Nette\DI\Statement
+	 */
+	private function parseChildren()
+	{
+		$arrayType = $this->getAttribute(self::ATTR_ARRAY, self::ATTR_ARRAY_ASSOCIATIVE);
+		$space = (string) $this->getAttribute(self::ATTR_SPACE);
+		if ($space !== self::ATTR_SPACE_PRESERVE and ! empty($space)) {
+			throw new Nette\InvalidStateException("Attribute " . self::ATTR_SPACE . " has an unknown value '$space'");
+		}
+
+		if ($arrayType === self::ATTR_ARRAY_STRING) {
+			$res = $this->parseStringArray();
+			$this->trim($res, $space);
+			return $res;
+		}
+
+		if (!$this->count()) {
+			$res = $this->getValue();
+			$this->trim($res, $space);
+			return $res;
+		}
+
+		$res = array();
+		switch ($arrayType) {
+			default:
+			case self::ATTR_ARRAY_ASSOCIATIVE:
+				foreach ($this->children() as $key => $child) {
+					if (isset($res[$key])) {
+						throw new Nette\InvalidStateException("Duplicated key '$key'.");
+					}
+					$res[$key] = $child->parse();
+				}
+				break;
+			case self::ATTR_ARRAY_NUMERIC:
+				foreach ($this->children() as $key => $child) {
+					$res[] = $child->parse();
+				}
+				break;
+		}
+
+		return $res;
+	}
+
+	/**
+	 * @param mixed $value
+	 * @param string $space
+	 */
+	private function trim(&$value, $space)
+	{
+		if ($space === self::ATTR_SPACE_PRESERVE) {
+			return;
+		}
+		if (is_array($value)) {
+			array_walk(
+				$value, function(& $val) {
+				if (is_string($val)) {
+					$val = trim($val);
+				}
+			}
+			);
+			return;
+		}
+
+		if (is_string($value)) {
+			$value = trim($value);
+		}
+	}
+
+	/**
+	 * Parse value of this element with attribute array="string"
+	 *
+	 * @return array
+	 */
+	private function parseStringArray()
+	{
+		if ($this->count() > 0) {
+			throw new Nette\InvalidStateException('Element with attribute array="string" can\'t have children: ' . $this->asXML());
+		}
+
+		$value = $this->getValue();
+		if (is_null($value)) {
+			return array();
+		}
+
+		$delimiter = $this->getAttribute(self::ATTR_DELIMITER, self::DEFAULT_DELIMITER);
+		return explode($delimiter[0], $value);
+	}
+
+}
+
+/**
+ * This class helps to save array into XML configuration
+ * @internal
+ */
+class XMLElementWritter extends \SimpleXMLElement
+{
+	/** Entity names */
+	const ENT_ITEM = 'item',
+		ENT_STATEMENT = 's',
+		ENT_STATEMENT_ENTITY = 'ent',
+		ENT_STATEMENT_ARGUMENTS = 'args';
+
+	/**
+	 * Construct XML DOM from config array
+	 * @param array $config
+	 */
+	public function addConfig(array $config, $element = NULL)
+	{
+		if ($element === NULL) {
+			$element = $this;
+		}
+
+		if (isset($config[Helpers::EXTENDS_KEY])) {
+			$section = $config[Helpers::EXTENDS_KEY];
+			if ($section === Helpers::OVERWRITE) {
+				$element->addAttribute(XMLElementParser::ATTR_MERGING, XMLElementParser::ATTR_MERGING_REPLACE);
+			} else {
+				$element->addAttribute(XMLElementParser::ATTR_EXTENDS, $section);
+			}
+			unset($config[Helpers::EXTENDS_KEY]);
+		}
+
+		$isNumeric = array_keys($config) === range(0, count($config) - 1);
+		if ($isNumeric) {
+			$element->addAttribute(XMLElementParser::ATTR_ARRAY, XMLElementParser::ATTR_ARRAY_NUMERIC);
+		}
+		foreach ($config as $name => $value) {
+			$name = $isNumeric ? self::ENT_ITEM : $name;
+			$this->addElement($element, $name, $value);
+		}
+	}
+
+	/**
+	 * @param \SimpleXmlElement $element
+	 * @param string $name
+	 * @param mixed $value
+	 * @return void
+	 */
+	private function addElement(\SimpleXMLElement $element, $name, $value)
+	{
+		if (is_string($value)) {
+			$element->addChild($name, $value);
+			return;
+		}
+		if ($value instanceof Statement) {
+			$this->addStatementList($element, $name, $value);
+			return;
+		}
+		$child = $element->addChild($name);
+		if ($value === NULL) {
+			$child->addAttribute(XMLElementParser::ATTR_NULL, XMLElementParser::ATTR_NULL_VALUE);
+		} elseif (is_bool($value)) {
+			$child->addAttribute(XMLElementParser::ATTR_BOOL, $value ? '1' : '0');
+		} elseif (is_numeric($value)) {
+			$child->addAttribute(XMLElementParser::ATTR_NUMBER, $value);
+		} elseif (is_array($value)) {
+			$this->addConfig($value, $child);
+		} else {
+			throw new \Nette\InvalidStateException("Unsupported type " . gettype($value));
+		}
+	}
+
+	/**
+	 * @param \SimpleXMLElement $element
+	 * @param string $name
+	 * @param \Statement $value
+	 * @return void
+	 */
+	private function addStatementList(\SimpleXMLElement $element, $name, Statement $value)
+	{
+		$child = $element->addChild($name);
+		$child->addAttribute(XMLElementParser::ATTR_STATEMENT, XMLElementParser::ATTR_STATEMENT);
+		$this->addStatement($child, $value);
+	}
+
+	/**
+	 *
+	 * @param \SimpleXMLElement $list
+	 * @param Statement $value
+	 * @return void
+	 * @throws Nette\InvalidStateException
+	 */
+	private function addStatement(\SimpleXMLElement $list, Statement $value)
+	{
+		if (!is_array($value->entity)) {
+			$child = $list->addChild(self::ENT_STATEMENT);
+			$child->addChild(self::ENT_STATEMENT_ENTITY, $value->entity);
+			$args = $child->addChild(self::ENT_STATEMENT_ARGUMENTS);
+			$this->addConfig($value->arguments, $args);
+			return;
+		}
+
+		if (!($value->entity[0] instanceof Statement)) {
+			throw new Nette\InvalidStateException("Unsupported statement state");
+		}
+		$this->addStatement($list, $value->entity[0]);
+		$this->addStatement($list, new Statement($value->entity[1], $value->arguments));
+	}
+
+}

--- a/src/DI/Config/Adapters/XmlAdapter.php
+++ b/src/DI/Config/Adapters/XmlAdapter.php
@@ -26,10 +26,10 @@ class XmlAdapter extends Nette\Object implements Nette\DI\Config\IAdapter
 	 */
 	public function load($file)
 	{
-		$opt = LIBXML_NOBLANKS | LIBXML_NOCDATA | LIBXML_NOENT | LIBXML_NSCLEAN; // | LIBXML_PEDANTIC ?
+		$options = LIBXML_NOBLANKS | LIBXML_NOCDATA | LIBXML_NOENT | LIBXML_NSCLEAN; // | LIBXML_PEDANTIC ?
 		$parserClass = "\\Nette\\DI\\Config\\Adapters\\XMLElementParser";
-		$doc = simplexml_load_file($file, $parserClass, $opt, self::NS);
-		return $doc->parse();
+		$document = simplexml_load_file($file, $parserClass, $options, self::NS);
+		return $document->parse();
 	}
 
 	/**
@@ -38,11 +38,11 @@ class XmlAdapter extends Nette\Object implements Nette\DI\Config\IAdapter
 	 */
 	public function dump(array $data)
 	{
-		$writter = new XmlElementWritter('<config/>', 0, false, self::NS, "nc");
-		$writter->addAttribute('xmlns:xmlns:nc', self::NS);
-		$writter->addAttribute('xmlns', self::NS);
-		$writter->addConfig($data);
-		return $writter->asXML();
+		$writer = new XmlElementWriter('<config/>', LIBXML_NOEMPTYTAG, false, self::NS, "nc");
+		$writer->addAttribute('xmlns:xmlns:nc', self::NS);
+		$writer->addAttribute('xmlns', self::NS);
+		$writer->addConfig($data);
+		return $writer->asXML();
 	}
 
 }
@@ -183,7 +183,7 @@ class XMLElementParser extends \SimpleXMLElement
 			if (!$res) {
 				$res = new Statement($entity, $arguments);
 			} else {
-				$res = new Statement(array($res, $entity), $arguments);
+				$res = new Statement([$res, $entity], $arguments);
 			}
 		}
 
@@ -208,7 +208,7 @@ class XMLElementParser extends \SimpleXMLElement
 
 		$argsElement = $child->args;
 		if (empty($argsElement)) {
-			return array($entity, NULL);
+			return [$entity, NULL];
 		}
 		$arrayAttr = $argsElement[0]->getAttribute(self::ATTR_ARRAY);
 		if (is_null($arrayAttr)) {
@@ -217,9 +217,9 @@ class XMLElementParser extends \SimpleXMLElement
 
 		$attributes = $argsElement[0]->parseChildren();
 		if (!is_array($attributes)) {
-			$attributes = array($attributes);
+			$attributes = [$attributes];
 		}
-		return array($entity, $attributes);
+		return [$entity, $attributes];
 	}
 
 	/**
@@ -247,7 +247,7 @@ class XMLElementParser extends \SimpleXMLElement
 			return $res;
 		}
 
-		$res = array();
+		$res = [];
 		switch ($arrayType) {
 			default:
 			case self::ATTR_ARRAY_ASSOCIATIVE:
@@ -306,7 +306,7 @@ class XMLElementParser extends \SimpleXMLElement
 
 		$value = $this->getValue();
 		if (is_null($value)) {
-			return array();
+			return [];
 		}
 
 		$delimiter = $this->getAttribute(self::ATTR_DELIMITER, self::DEFAULT_DELIMITER);
@@ -319,7 +319,7 @@ class XMLElementParser extends \SimpleXMLElement
  * This class helps to save array into XML configuration
  * @internal
  */
-class XMLElementWritter extends \SimpleXMLElement
+class XMLElementWriter extends \SimpleXMLElement
 {
 	/** Entity names */
 	const ENT_ITEM = 'item',

--- a/src/DI/Config/Loader.php
+++ b/src/DI/Config/Loader.php
@@ -23,6 +23,7 @@ class Loader extends Nette\Object
 		'php' => 'Nette\DI\Config\Adapters\PhpAdapter',
 		'ini' => 'Nette\DI\Config\Adapters\IniAdapter',
 		'neon' => 'Nette\DI\Config\Adapters\NeonAdapter',
+		'xml' => 'Nette\DI\Config\Adapters\XmlAdapter'
 	];
 
 	private $dependencies = [];
@@ -69,7 +70,7 @@ class Loader extends Nette\Object
 	 * @param  string  file
 	 * @return void
 	 */
-	public function save($data, $file)
+	public function save(array $data, $file)
 	{
 		if (file_put_contents($file, $this->getAdapter($file)->dump($data)) === FALSE) {
 			throw new Nette\IOException("Cannot write file '$file'.");

--- a/tests/DI/XmlAdapter.errors.phpt
+++ b/tests/DI/XmlAdapter.errors.phpt
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Test: Nette\DI\Config\Adapters\XmlAdapter errors.
+ */
+
+use Nette\DI\Config;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+Assert::exception(function () {
+	$config = new Config\Loader;
+	$config->load('files/xmlAdapter.error1.xml');
+}, 'Nette\InvalidStateException', "Duplicated key 'scalar'.");
+
+Assert::exception(function () {
+	$config = new Config\Loader;
+	$config->load('files/xmlAdapter.error2.xml');
+}, 'Nette\InvalidStateException', "Replacing operator is available only for arrays, element 'test' is not array");
+
+Assert::exception(function () {
+	$config = new Config\Loader;
+	$config->load('files/xmlAdapter.error3.xml');
+}, 'Nette\InvalidStateException', 'Expected <ent> element in statement <factory statement="statement"><s>DateTime<args><a>0</a></args></s></factory>');
+
+Assert::exception(function () {
+	$config = new Config\Loader;
+	$config->load('files/xmlAdapter.error4.xml');
+}, 'Nette\InvalidStateException', 'Element <ent> must have a non-empty string value.');
+
+Assert::exception(function () {
+	$config = new Config\Loader;
+	$config->load('files/xmlAdapter.error5.xml');
+}, 'Nette\InvalidStateException', "Attribute space has an unknown value 'perverse'");
+
+Assert::exception(function () {
+	$config = new Config\Loader;
+	$config->load('files/xmlAdapter.error6.xml');
+}, 'Nette\InvalidStateException', 'Element with attribute array="string" can\'t have children: <test array="string"><child>a,b,c</child></test>');

--- a/tests/DI/XmlAdapter.phpt
+++ b/tests/DI/XmlAdapter.phpt
@@ -63,12 +63,13 @@ EOD
 
 $data = $config->load('files/xmlAdapter.xml');
 $config->save($data, TEMP_FILE);
+$actual = file_get_contents(TEMP_FILE);
+$actual = preg_replace('/\<(\w+)\s*\/\s*\>/i', '<$1></$1>', $actual);
 Assert::match(<<<EOD
 <?xml version="1.0"?>
-<config xmlns:nc="http://www.nette.org/xmlns/nette/config/1.0" xmlns="http://www.nette.org/xmlns/nette/config/1.0"><production><webname>the example</webname><database><adapter>pdo_mysql</adapter><params><host>db.example.com</host><username>dbuser</username><password>secret </password><dbname>dbname</dbname></params></database></production><development extends="production"><database><params><host>dev.example.com</host><username>devuser</username><password>devsecret</password></params></database><timeout number="10"/><display_errors bool="1"/><html_errors bool="0"/><items array="numeric"><item number="10"/><item number="20"/></items><php><zlib.output_compression bool="1"/><date.timezone>Europe/Prague</date.timezone></php></development><nothing/></config>
+<config xmlns:nc="http://www.nette.org/xmlns/nette/config/1.0" xmlns="http://www.nette.org/xmlns/nette/config/1.0"><production><webname>the example</webname><database><adapter>pdo_mysql</adapter><params><host>db.example.com</host><username>dbuser</username><password>secret </password><dbname>dbname</dbname></params></database></production><development extends="production"><database><params><host>dev.example.com</host><username>devuser</username><password>devsecret</password></params></database><timeout number="10"/><display_errors bool="1"/><html_errors bool="0"/><items array="numeric"><item number="10"/><item number="20"/></items><php><zlib.output_compression bool="1"/><date.timezone>Europe/Prague</date.timezone></php></development><nothing></nothing></config>
 EOD
-, file_get_contents(TEMP_FILE));
-
+, $actual);
 
 $data = $config->load('files/xmlAdapter.entity.xml');
 Assert::equal([

--- a/tests/DI/XmlAdapter.phpt
+++ b/tests/DI/XmlAdapter.phpt
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * Test: Nette\DI\Config\Adapters\xmldapter
+ */
+
+use Nette\DI\Config;
+use Nette\DI\Statement;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+define('TEMP_FILE', TEMP_DIR . '/cfg.xml');
+
+
+$config = new Config\Loader;
+$data = $config->load('files/xmlAdapter.xml', 'production');
+Assert::same([
+	'webname' => 'the example',
+	'database' => [
+		'adapter' => 'pdo_mysql',
+		'params' => [
+			'host' => 'db.example.com',
+			'username' => 'dbuser',
+			'password' => 'secret ',
+			'dbname' => 'dbname',
+		],
+	],
+], $data);
+
+
+$data = $config->load('files/xmlAdapter.xml', 'development');
+Assert::same([
+	'webname' => 'the example',
+	'database' => [
+		'adapter' => 'pdo_mysql',
+		'params' => [
+			'host' => 'dev.example.com',
+			'username' => 'devuser',
+			'password' => 'devsecret',
+			'dbname' => 'dbname',
+		],
+	],
+	'timeout' => 10,
+	'display_errors' => TRUE,
+	'html_errors' => FALSE,
+	'items' => [10, 20],
+	'php' => [
+		'zlib.output_compression' => TRUE,
+		'date.timezone' => 'Europe/Prague',
+	],
+], $data);
+
+
+$config->save($data, TEMP_FILE);
+Assert::match(<<<EOD
+<?xml version="1.0"?>
+<config xmlns:nc="http://www.nette.org/xmlns/nette/config/1.0" xmlns="http://www.nette.org/xmlns/nette/config/1.0"><webname>the example</webname><database><adapter>pdo_mysql</adapter><params><host>dev.example.com</host><username>devuser</username><password>devsecret</password><dbname>dbname</dbname></params></database><timeout number="10"/><display_errors bool="1"/><html_errors bool="0"/><items array="numeric"><item number="10"/><item number="20"/></items><php><zlib.output_compression bool="1"/><date.timezone>Europe/Prague</date.timezone></php></config>
+EOD
+, file_get_contents(TEMP_FILE));
+
+
+$data = $config->load('files/xmlAdapter.xml');
+$config->save($data, TEMP_FILE);
+Assert::match(<<<EOD
+<?xml version="1.0"?>
+<config xmlns:nc="http://www.nette.org/xmlns/nette/config/1.0" xmlns="http://www.nette.org/xmlns/nette/config/1.0"><production><webname>the example</webname><database><adapter>pdo_mysql</adapter><params><host>db.example.com</host><username>dbuser</username><password>secret </password><dbname>dbname</dbname></params></database></production><development extends="production"><database><params><host>dev.example.com</host><username>devuser</username><password>devsecret</password></params></database><timeout number="10"/><display_errors bool="1"/><html_errors bool="0"/><items array="numeric"><item number="10"/><item number="20"/></items><php><zlib.output_compression bool="1"/><date.timezone>Europe/Prague</date.timezone></php></development><nothing/></config>
+EOD
+, file_get_contents(TEMP_FILE));
+
+
+$data = $config->load('files/xmlAdapter.entity.xml');
+Assert::equal([
+	new Statement('ent', [1]),
+	new Statement([
+			new Statement('ent', [2]),
+			'inner',
+		],
+		['3', '4']
+	),
+	new Statement([
+			new Statement('ent', ['3']),
+			'inner',
+		],
+		['5','6']
+	),
+], $data);
+
+$data = $config->load('files/xmlAdapter.entity.xml');
+$config->save($data, TEMP_FILE);
+Assert::match(<<<EOD
+<?xml version="1.0"?>
+<config xmlns:nc="http://www.nette.org/xmlns/nette/config/1.0" xmlns="http://www.nette.org/xmlns/nette/config/1.0" array="numeric"><item statement="statement"><s><ent>ent</ent><args array="numeric"><item number="1"/></args></s></item><item statement="statement"><s><ent>ent</ent><args array="numeric"><item number="2"/></args></s><s><ent>inner</ent><args array="numeric"><item>3</item><item>4</item></args></s></item><item statement="statement"><s><ent>ent</ent><args array="numeric"><item>3</item></args></s><s><ent>inner</ent><args array="numeric"><item>5</item><item>6</item></args></s></item></config>
+EOD
+, file_get_contents(TEMP_FILE));

--- a/tests/DI/XmlAdapter.services.phpt
+++ b/tests/DI/XmlAdapter.services.phpt
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Test: Nette\DI\Config\Adapters\XmlAdapter
+ */
+
+use Nette\DI\Config\Adapters\XmlAdapter;
+use Nette\DI\Statement;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+$adapter = new XmlAdapter;
+$data = $adapter->load('files/xmlAdapter.services.xml');
+
+Assert::equal(
+	[
+		new Statement('Class', [
+			'arg1',
+			new Nette\DI\Statement('Class2', ['arg2', 'arg3']),
+		]),
+		new Statement('Class', [
+			'arg1',
+			new Nette\DI\Statement('Class2', ['arg2', 'arg3']),
+		]),
+	],
+	$data
+);

--- a/tests/DI/files/xmlAdapter.entity.xml
+++ b/tests/DI/files/xmlAdapter.entity.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config xmlns:nc="http://www.nette.org/xmlns/nette/config/1.0" xmlns="http://www.nette.org/xmlns/nette/config/1.0" array="numeric">
+<e statement="ent(1)" />
+<e statement="statement">
+	<s>
+		<ent>ent</ent>
+		<args><a number="2" /></args>
+	</s>
+	<s>
+		<ent>inner</ent>
+		<args array="string">3,4</args>
+	</s>
+</e>
+<e statement="statement">
+	<s>
+		<ent>ent</ent>
+		<args>3</args>
+	</s>
+	<s>
+		<ent>inner</ent>
+		<args array="string" delimiter=";">5; 6</args>
+	</s>
+</e>
+</config>

--- a/tests/DI/files/xmlAdapter.error1.xml
+++ b/tests/DI/files/xmlAdapter.error1.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config xmlns:nc="http://www.nette.org/xmlns/nette/config/1.0" xmlns="http://www.nette.org/xmlns/nette/config/1.0">
+<scalar>10</scalar>
+
+<scalar extends="parent">
+	<date>timezone = "Europe/Paris"</date>
+</scalar>
+</config>

--- a/tests/DI/files/xmlAdapter.error2.xml
+++ b/tests/DI/files/xmlAdapter.error2.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config xmlns:nc="http://www.nette.org/xmlns/nette/config/1.0" xmlns="http://www.nette.org/xmlns/nette/config/1.0">
+<test merging="replace">
+	just an example example
+</test>
+</config>

--- a/tests/DI/files/xmlAdapter.error3.xml
+++ b/tests/DI/files/xmlAdapter.error3.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config xmlns:nc="http://www.nette.org/xmlns/nette/config/1.0" xmlns="http://www.nette.org/xmlns/nette/config/1.0">
+<factory statement="statement"><s>DateTime<args><a>0</a></args></s></factory>
+</config>

--- a/tests/DI/files/xmlAdapter.error4.xml
+++ b/tests/DI/files/xmlAdapter.error4.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config xmlns:nc="http://www.nette.org/xmlns/nette/config/1.0" xmlns="http://www.nette.org/xmlns/nette/config/1.0">
+<factory statement="statement"><s><ent></ent><args><a>0</a></args></s></factory>
+</config>

--- a/tests/DI/files/xmlAdapter.error5.xml
+++ b/tests/DI/files/xmlAdapter.error5.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config xmlns:nc="http://www.nette.org/xmlns/nette/config/1.0" xmlns="http://www.nette.org/xmlns/nette/config/1.0">
+<test space="perverse">just an example example</test>
+</config>

--- a/tests/DI/files/xmlAdapter.error6.xml
+++ b/tests/DI/files/xmlAdapter.error6.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config xmlns:nc="http://www.nette.org/xmlns/nette/config/1.0" xmlns="http://www.nette.org/xmlns/nette/config/1.0">
+<test array="string"><child>a,b,c</child></test>
+</config>

--- a/tests/DI/files/xmlAdapter.services.xml
+++ b/tests/DI/files/xmlAdapter.services.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config xmlns:nc="http://www.nette.org/xmlns/nette/config/1.0" xmlns="http://www.nette.org/xmlns/nette/config/1.0" array="numeric">
+<service statement="Class(arg1, Class2(arg2, arg3))" />
+<service statement="statement">
+	<s>
+		<ent>Class</ent>
+		<args>
+			<a>arg1</a>
+			<a statement="statement">
+					<s>
+						<ent>Class2</ent>
+						<args>
+							<a>arg2</a>
+							<a>arg3</a>
+						</args>
+					</s>
+			</a>
+		</args>
+	</s>
+</service>
+</config>
+

--- a/tests/DI/files/xmlAdapter.services.xml
+++ b/tests/DI/files/xmlAdapter.services.xml
@@ -19,4 +19,3 @@
 	</s>
 </service>
 </config>
-

--- a/tests/DI/files/xmlAdapter.xml
+++ b/tests/DI/files/xmlAdapter.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config xmlns:nc="http://www.nette.org/xmlns/nette/config/1.0" xmlns="http://www.nette.org/xmlns/nette/config/1.0">
+<production>
+	<webname>the example</webname>
+	<database>
+		<adapter>pdo_mysql </adapter>
+		<params>
+			<host>db.example.com</host>
+			<username>dbuser</username>
+			<password space="preserve">secret </password>
+			<dbname>dbname</dbname>
+		</params>
+	</database>
+</production>
+<!-- inherits from production and overrides values as necessary -->
+<development extends="production">
+	<database>
+		<params>
+			<host>dev.example.com</host>
+			<username>devuser</username>
+			<password>devsecret</password>
+		</params>
+	</database>
+	<timeout number="10" />
+	<display_errors bool="true" />
+	<html_errors bool="no"/>
+	<items array="numeric"><i number="10"/><i number="20"/></items>
+	<php>
+		<zlib.output_compression bool="true" />
+		<date.timezone>Europe/Prague</date.timezone>
+	</php>
+</development>
+<nothing />
+</config>


### PR DESCRIPTION
# Xml Adapter
XML adapter could be used to write configuration in XML. 
Thanks to namespace usage (http://www.nette.org/xmlns/nette/config/1.0) you can have  configuration common for nette and other application, configuration for nette  only and  for other application only in the same file.

For basic usage example: see [tests/DI/files/xmlAdapter.xml](tests/DI/files/xmlAdapter.xml)

## Supported types

### Associative array 

```xml
<myarray><key1>value1</key1><key2>value2</key2></myarray>
```
Becomes:
```php
[key1 => 'value1', key2=>'value2']
```
### Numeric array

```xml
<myarray array="numeric"><key>value1</key><key>value2</key></myarray>
```
Becomes (*element names are ignored here*):
```php
[0=>'value1',1=>'value2]
```
### String, Null, Number, Boolean

```xml
<myarray array="numeric">
<x> trimmed string </x>
<x space="preserve"> string with spaces  </x>
<x>1</x>
<x number="2"/>
<x bool="yes"/>
<x null="null" />
</myarray>
```
Becomes:
```php
["trimmed string", " string with spaces  ","1", 2, TRUE, NULL]
```
*Bool support "yes", "true", "on" and "1"*
### Statement
```xml
<factory statement="statement">
    <s><ent>DateTime</ent><args><a numeric="0" /></args></s>
   <s><ent>format</ent><args><a>%B</a></args></s>
</factory>
```
Is equivalent to neon: ```DateTime(0)::format("%B")```

## Syntactic sugar

### Array from string
```xml
<myarray array="string">1,2,3</myarray>
```
Becomes:
```php
["1", "2", "3"]
```
#### The same with custom delimiter:
```xml
<myarray array="string" delimiter=";">1;2;3</myarray>
```

### Statement
Of course you can use array from string in statement arguments.
```xml
<xxx statement="statement">
<s><ent>fooo</ent><args array="string" delimiter=";">1;2;3</args></s>
</xxx>
```
If there is only one argument, you dont need to use element inside args element.
These statements are equivalent:
```xml
<xxx statement="statement"><s><ent>fooo</ent><args><a>1</a></args></s></xxx>
<xxx statement="statement"><s><ent>fooo</ent><args>1</args></s></xxx>
```

You can use neon syntax for statement:
```xml
<xxx statement="DateTime(0)::format('%B')" />
```

## Example of converting neon config file to xml config file

```php
use Nette\DI\Config\Adapters\NeonAdapter;
use Nette\DI\Config\Adapters\XmlAdapter;

$na = NeonAdapter;
$xa = XmlAdapter;
$config = $na->load('config.neon');
$xmlConfig = $xmlloader->dump($config);
// pretty output
$domxml = new DOMDocument('1.0');
$domxml->preserveWhiteSpace = false;
$domxml->formatOutput = true;
$domxml->loadXML($xmlConfig);
echo $domxml->saveXML();
```
