### PR TITLE
Support for PHP7 return types and scalar parameters for factories

### DIFF
--- a/src/DI/ContainerBuilder.php
+++ b/src/DI/ContainerBuilder.php
@@ -421,7 +421,7 @@ class ContainerBuilder extends Nette\Object
 		if ($class = $def->getClass() ?: $class) {
 			$def->setClass($class);
 			if (!class_exists($class) && !interface_exists($class)) {
-				throw new ServiceCreationException("Class or interface $class used in service '$name' not found.");
+				throw new ServiceCreationException("Type $class used in service '$name' not found.");
 			}
 			self::checkCase($class);
 
@@ -638,7 +638,8 @@ class ContainerBuilder extends Nette\Object
 
 		$factoryClass->addMethod($def->getImplementType())
 			->setParameters($this->convertParameters($def->parameters))
-			->setBody(str_replace('$this', '$this->container', $code));
+			->setBody(str_replace('$this', '$this->container', $code))
+			->setReturnType(PHP_VERSION_ID >= 70000 ? $def->getClass() : NULL);
 
 		return "return new {$factoryClass->getName()}(\$this);";
 	}

--- a/src/DI/PhpReflection.php
+++ b/src/DI/PhpReflection.php
@@ -59,7 +59,9 @@ class PhpReflection
 	 */
 	public static function getParameterType(\ReflectionParameter $param)
 	{
-		if ($param->isArray() || $param->isCallable()) {
+		if (PHP_VERSION_ID >= 70000 && $param->hasType()) {
+			return (string) $param->getType();
+		} elseif ($param->isArray() || $param->isCallable()) {
 			return $param->isArray() ? 'array' : 'callable';
 		} else {
 			try {
@@ -79,6 +81,9 @@ class PhpReflection
 	 */
 	public static function getReturnType(\ReflectionFunctionAbstract $func)
 	{
+		if (PHP_VERSION_ID >= 70000 && $func->hasReturnType()) {
+			return (string) $func->getReturnType();
+		}
 		$type = preg_replace('#[|\s].*#', '', (string) self::parseAnnotation($func, 'return'));
 		if ($type) {
 			return $func instanceof \ReflectionMethod

--- a/tests/DI/Compiler.generatedFactory.returnTypes.phpt
+++ b/tests/DI/Compiler.generatedFactory.returnTypes.phpt
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Test: Nette\DI\Compiler: generated services factories from interfaces with return type declarations.
+ * @phpVersion 7.0
+ */
+
+use Nette\DI;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+interface IArticleFactory
+{
+
+	function create($title): Article;
+}
+
+class Article
+{
+	public $title;
+
+	function __construct($title)
+	{
+		$this->title = $title;
+	}
+}
+
+$compiler = new DI\Compiler;
+$container = createContainer($compiler, 'files/compiler.generatedFactory.returnTypes.neon');
+
+Assert::type('IArticleFactory', $container->getService('article'));
+$article = $container->getService('article')->create('lorem-ipsum');
+Assert::type('Article', $article);
+Assert::same('lorem-ipsum', $article->title);
+
+Assert::type('IArticleFactory', $container->getService('article2'));
+$article = $container->getService('article2')->create('lorem-ipsum');
+Assert::type('Article', $article);
+Assert::same('lorem-ipsum', $article->title);

--- a/tests/DI/Compiler.generatedFactory.scalarParameters.phpt
+++ b/tests/DI/Compiler.generatedFactory.scalarParameters.phpt
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Test: Nette\DI\Compiler: generated services factories from interfaces with scalar type hints in parameters.
+ * @phpVersion 7.0
+ */
+
+use Nette\DI;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+interface IArticleFactory
+{
+
+	/** @return Article */
+	function create(string $title);
+}
+
+class Article
+{
+	public $title;
+
+	function __construct(string $title)
+	{
+		$this->title = $title;
+	}
+}
+
+$compiler = new DI\Compiler;
+$container = createContainer($compiler, 'files/compiler.generatedFactory.scalarParameters.neon');
+
+Assert::type('IArticleFactory', $container->getService('article'));
+$article = $container->getService('article')->create('lorem-ipsum');
+Assert::type('Article', $article);
+Assert::same('lorem-ipsum', $article->title);
+
+Assert::type('IArticleFactory', $container->getService('article2'));
+$article = $container->getService('article2')->create('lorem-ipsum');
+Assert::type('Article', $article);
+Assert::same('lorem-ipsum', $article->title);
+
+Assert::type('IArticleFactory', $container->getService('article3'));
+$article = $container->getService('article3')->create('lorem-ipsum');
+Assert::type('Article', $article);
+Assert::same('lorem-ipsum', $article->title);

--- a/tests/DI/ContainerBuilder.factory.resolveBuiltinTypes.php5.phpt
+++ b/tests/DI/ContainerBuilder.factory.resolveBuiltinTypes.php5.phpt
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Test: Nette\DI\ContainerBuilder and resolving builtin types for generated factories.
+ */
+
+namespace A
+{
+
+	class Factory
+	{
+		/** @return array */
+		function createArray()
+		{
+			return [];
+		}
+
+		/** @return callable */
+		function createCallable()
+		{
+			return function () {};
+		}
+	}
+
+}
+
+namespace
+{
+	use Nette\DI;
+	use Tester\Assert;
+
+
+	require __DIR__ . '/../bootstrap.php';
+
+	Assert::exception(function () {
+		$builder = new DI\ContainerBuilder;
+		$builder->addDefinition('factory')
+			->setClass('A\Factory');
+		$builder->addDefinition('a')
+			->setFactory('@factory::createArray');
+		$container = createContainer($builder);
+	}, Nette\DI\ServiceCreationException::class, "Type array used in service 'a' not found.");
+
+	Assert::exception(function () {
+		$builder = new DI\ContainerBuilder;
+		$builder->addDefinition('factory')
+			->setClass('A\Factory');
+		$builder->addDefinition('c')
+			->setFactory('@factory::createCallable');
+		$container = createContainer($builder);
+	}, Nette\DI\ServiceCreationException::class, "Type callable used in service 'c' not found.");
+
+}

--- a/tests/DI/ContainerBuilder.factory.resolveBuiltinTypes.php7.phpt
+++ b/tests/DI/ContainerBuilder.factory.resolveBuiltinTypes.php7.phpt
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Test: Nette\DI\ContainerBuilder and resolving builtin types for generated factories. Added checks for types added in PHP 7.0.
+ * @phpVersion 7.0
+ */
+
+namespace A
+{
+
+	class Factory
+	{
+		/** @return string */
+		function createString()
+		{
+			return "";
+		}
+
+		/** @return int */
+		function createInt()
+		{
+			return 0;
+		}
+
+		function createBool(): bool
+		{
+			return FALSE;
+		}
+
+		function createFloat(): float
+		{
+			return 0.0;
+		}
+	}
+
+}
+
+namespace
+{
+	use Nette\DI;
+	use Tester\Assert;
+
+
+	require __DIR__ . '/../bootstrap.php';
+
+
+	Assert::exception(function () {
+		$builder = new DI\ContainerBuilder;
+		$builder->addDefinition('factory')
+			->setClass('A\Factory');
+		$builder->addDefinition('s')
+			->setFactory('@factory::createString');
+		$container = createContainer($builder);
+	}, Nette\DI\ServiceCreationException::class, "Type string used in service 's' not found.");
+
+	Assert::exception(function () {
+		$builder = new DI\ContainerBuilder;
+		$builder->addDefinition('factory')
+			->setClass('A\Factory');
+		$builder->addDefinition('i')
+			->setFactory('@factory::createInt');
+		$container = createContainer($builder);
+	}, Nette\DI\ServiceCreationException::class, "Type int used in service 'i' not found.");
+
+	Assert::exception(function () {
+		$builder = new DI\ContainerBuilder;
+		$builder->addDefinition('factory')
+			->setClass('A\Factory');
+		$builder->addDefinition('b')
+			->setFactory('@factory::createBool');
+		$container = createContainer($builder);
+	}, Nette\DI\ServiceCreationException::class, "Type bool used in service 'b' not found.");
+
+	Assert::exception(function () {
+		$builder = new DI\ContainerBuilder;
+		$builder->addDefinition('factory')
+			->setClass('A\Factory');
+		$builder->addDefinition('f')
+			->setFactory('@factory::createFloat');
+		$container = createContainer($builder);
+	}, Nette\DI\ServiceCreationException::class, "Type float used in service 'f' not found.");
+
+}

--- a/tests/DI/ContainerBuilder.factory.resolveClass.returnTypes.phpt
+++ b/tests/DI/ContainerBuilder.factory.resolveClass.returnTypes.phpt
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Test: Nette\DI\ContainerBuilder and resolving class in generated factories. Return type is located in method signature instead of @return annotation.
+ * @phpVersion 7.0
+ */
+
+namespace A
+{
+	use B\Bar;
+
+	class Factory
+	{
+		function createBar(): Bar
+		{
+			return new Bar();
+		}
+	}
+
+}
+
+namespace B
+{
+
+	class Bar
+	{
+
+	}
+
+}
+
+namespace
+{
+	use Nette\DI;
+	use Tester\Assert;
+
+
+	require __DIR__ . '/../bootstrap.php';
+
+
+	$builder = new DI\ContainerBuilder;
+
+	$builder->addDefinition('one')
+		->setClass('A\Factory');
+
+	$builder->addDefinition('two')
+		->setFactory('@one::createBar');
+
+
+	$container = createContainer($builder);
+
+	Assert::type('B\Bar', $container->getByType('B\Bar'));
+}

--- a/tests/DI/files/compiler.generatedFactory.returnTypes.neon
+++ b/tests/DI/files/compiler.generatedFactory.returnTypes.neon
@@ -1,0 +1,11 @@
+services:
+
+	article:
+		create: Article(%title%)
+		implement: IArticleFactory
+		parameters: [title]
+
+	article2:
+		implement: IArticleFactory
+		arguments: [%title%]
+		parameters: [title]

--- a/tests/DI/files/compiler.generatedFactory.scalarParameters.neon
+++ b/tests/DI/files/compiler.generatedFactory.scalarParameters.neon
@@ -1,0 +1,14 @@
+services:
+
+	article:
+		create: Article(%title%)
+		implement: IArticleFactory
+		parameters: [string title]
+
+	article2:
+		implement: IArticleFactory
+		arguments: [%title%]
+		parameters: [string title]
+
+	article3:
+		implement: IArticleFactory


### PR DESCRIPTION
**Depends on https://github.com/nette/php-generator/pull/11**

- feature
- documentation - not needed
- BC break - no

Adds support for PHP 7 syntax and features:
- factories can now use return type declarations instead of the `@return` annotation
- scalar type hints can be used in parameters of the factory interfaces