### PR TITLE
Alternative autowiring approach [WIP]

### DIFF
--- a/src/DI/Compiler.php
+++ b/src/DI/Compiler.php
@@ -396,7 +396,7 @@ class Compiler
 		}
 
 		if (isset($config['autowired'])) {
-			Validators::assertField($config, 'autowired', 'bool');
+			Validators::assertField($config, 'autowired', 'bool|string|array');
 			$definition->setAutowired($config['autowired']);
 		}
 

--- a/src/DI/ServiceDefinition.php
+++ b/src/DI/ServiceDefinition.php
@@ -36,7 +36,7 @@ class ServiceDefinition
 	/** @var array */
 	private $tags = [];
 
-	/** @var bool */
+	/** @var bool|string[] */
 	private $autowired = TRUE;
 
 	/** @var bool */
@@ -210,21 +210,30 @@ class ServiceDefinition
 
 
 	/**
-	 * @param  bool
+	 * @param  bool|string|string[]
 	 * @return self
 	 */
 	public function setAutowired($state = TRUE)
 	{
 		call_user_func($this->notifier);
-		$this->autowired = (bool) $state;
+		$this->autowired = is_string($state) || is_array($state) ? (array) $state : (bool) $state;
 		return $this;
 	}
 
 
 	/**
-	 * @return bool
+	 * @return bool|string[]
 	 */
 	public function isAutowired()
+	{
+		return $this->autowired;
+	}
+
+
+	/**
+	 * @return bool|string[]
+	 */
+	public function getAutowired()
 	{
 		return $this->autowired;
 	}

--- a/tests/DI/ContainerBuilder.autowiring.types.phpt
+++ b/tests/DI/ContainerBuilder.autowiring.types.phpt
@@ -1,0 +1,201 @@
+<?php
+
+/**
+ * Test: Nette\DI\ContainerBuilder and direct types
+ */
+
+use Nette\DI;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+interface IFoo
+{
+}
+
+interface IBar
+{
+}
+
+class Foo implements IFoo
+{
+}
+
+class Bar extends Foo implements IBar
+{
+}
+
+
+test(function () {
+	$builder = new DI\ContainerBuilder;
+	$builder->addDefinition('bar')
+		->setClass('Bar')
+		->setAutowired('Bar');
+
+	Assert::same('bar', $builder->getByType('Bar'));
+	Assert::same(NULL, $builder->getByType('IBar'));
+	Assert::same(NULL, $builder->getByType('Foo'));
+	Assert::same(NULL, $builder->getByType('IFoo'));
+});
+
+
+test(function () {
+	$builder = new DI\ContainerBuilder;
+	$builder->addDefinition('bar')
+		->setClass('Bar')
+		->setAutowired('IBar');
+
+	Assert::same('bar', $builder->getByType('Bar'));
+	Assert::same('bar', $builder->getByType('IBar'));
+	Assert::same(NULL, $builder->getByType('Foo'));
+	Assert::same(NULL, $builder->getByType('IFoo'));
+});
+
+
+test(function () {
+	$builder = new DI\ContainerBuilder;
+	$builder->addDefinition('bar')
+		->setClass('Bar')
+		->setAutowired('Foo');
+
+	Assert::same('bar', $builder->getByType('Bar'));
+	Assert::same(NULL, $builder->getByType('IBar'));
+	Assert::same('bar', $builder->getByType('Foo'));
+	Assert::same(NULL, $builder->getByType('IFoo'));
+});
+
+
+test(function () {
+	$builder = new DI\ContainerBuilder;
+	$builder->addDefinition('bar')
+		->setClass('Bar')
+		->setAutowired('IFoo');
+
+	Assert::same('bar', $builder->getByType('Bar'));
+	Assert::same(NULL, $builder->getByType('IBar'));
+	Assert::same('bar', $builder->getByType('Foo'));
+	Assert::same('bar', $builder->getByType('IFoo'));
+});
+
+
+test(function () {
+	$builder = new DI\ContainerBuilder;
+	$builder->addDefinition('bar')
+		->setClass('Bar')
+		->setAutowired(['IFoo', 'IBar']);
+
+	Assert::same('bar', $builder->getByType('Bar'));
+	Assert::same('bar', $builder->getByType('IBar'));
+	Assert::same('bar', $builder->getByType('Foo'));
+	Assert::same('bar', $builder->getByType('IFoo'));
+});
+
+
+test(function () {
+	$builder = new DI\ContainerBuilder;
+	$builder->addDefinition('bar')
+		->setClass('Bar')
+		->setAutowired(['Foo', 'Bar']);
+
+	Assert::same('bar', $builder->getByType('Bar'));
+	Assert::same(NULL, $builder->getByType('IBar'));
+	Assert::same('bar', $builder->getByType('Foo'));
+	Assert::same(NULL, $builder->getByType('IFoo'));
+});
+
+
+test(function () {
+	$builder = new DI\ContainerBuilder;
+	$builder->addDefinition('bar')
+		->setClass('Bar')
+		->setAutowired(['Foo', 'IBar']);
+
+	Assert::same('bar', $builder->getByType('Bar'));
+	Assert::same('bar', $builder->getByType('IBar'));
+	Assert::same('bar', $builder->getByType('Foo'));
+	Assert::same(NULL, $builder->getByType('IFoo'));
+});
+
+
+test(function () {
+	$builder = new DI\ContainerBuilder;
+	$builder->addDefinition('bar')
+		->setClass('Bar')
+		->setAutowired(['IFoo', 'Bar']);
+
+	Assert::same('bar', $builder->getByType('Bar'));
+	Assert::same(NULL, $builder->getByType('IBar'));
+	Assert::same('bar', $builder->getByType('Foo'));
+	Assert::same('bar', $builder->getByType('IFoo'));
+});
+
+
+test(function () {
+	$builder = new DI\ContainerBuilder;
+	$builder->addDefinition('bar')
+		->setClass('Bar')
+		->setAutowired('Bar');
+
+	$builder->addDefinition('foo')
+		->setClass('Foo')
+		->setAutowired();
+
+	Assert::same('bar', $builder->getByType('Bar'));
+	Assert::null($builder->getByType('IBar'));
+	Assert::same('foo', $builder->getByType('Foo'));
+	Assert::same('foo', $builder->getByType('IFoo'));
+});
+
+
+test(function () {
+	$builder = new DI\ContainerBuilder;
+	$builder->addDefinition('bar')
+		->setClass('Bar')
+		->setAutowired(['Bar', 'IFoo']);
+
+	$builder->addDefinition('foo')
+		->setClass('Foo')
+		->setAutowired();
+
+	Assert::same('bar', $builder->getByType('Bar'));
+	Assert::null($builder->getByType('IBar'));
+	Assert::same('bar', $builder->getByType('Foo'));
+	Assert::same('bar', $builder->getByType('IFoo'));
+});
+
+
+test(function () {
+	$builder = new DI\ContainerBuilder;
+	$bar = $builder->addDefinition('bar')
+		->setClass('Bar')
+		->setAutowired(['Bar', 'IFoo']);
+
+	$foo = $builder->addDefinition('foo')
+		->setClass('Foo')
+		->setAutowired('IFoo');
+
+	Assert::same('bar', $builder->getByType('Bar'));
+	Assert::null($builder->getByType('IBar'));
+
+	Assert::exception(function () use ($builder) {
+		$builder->getByType('Foo');
+	}, DI\ServiceCreationException::class, 'Multiple services of type Foo found: bar, foo');
+
+	Assert::exception(function () use ($builder) {
+		$builder->getByType('IFoo');
+	}, DI\ServiceCreationException::class, 'Multiple services of type IFoo found: bar, foo');
+});
+
+
+test(function () {
+	$builder = new DI\ContainerBuilder;
+	$bar = $builder->addDefinition('bar')
+		->setClass('Foo')
+		->setAutowired(['Bar']);
+
+	Assert::exception(function () use ($builder) {
+		$builder->getByType('Foo');
+	}, DI\ServiceCreationException::class, "Incompatible class Bar in autowiring definition of service 'bar'.");
+});


### PR DESCRIPTION
~~All services are autowired. `setAutowired(TRUE)` means that service is preferred, `setAutowired(FALSE)` means that is autowired too, but not preferred (yes, name `setAutowired(FALSE)` is weird here, but this is just experiment).~~

Only services that are excluded via `$excludedClasses` are not autowired.

~~Now you can create services FileStorage (autowired: on) and DevNullStorage (autowired: off) and access the first one via `getByType('IStorage') and second one via `getByType('DevNullStorage')`.~~

I tried [a different approach](https://github.com/nette/di/pull/84#issuecomment-217701242)
