### PR TITLE
Compiler::parseServices: allow prefixing service name in the config

### DIFF
--- a/src/DI/Compiler.php
+++ b/src/DI/Compiler.php
@@ -255,6 +255,9 @@ class Compiler
 				$builder->removeDefinition($name);
 				continue;
 			}
+			if ($namespace) {
+				$def = Helpers::prefixServiceName($def, $namespace);
+			}
 
 			$params = $builder->parameters;
 			if (is_array($def) && isset($def['parameters'])) {

--- a/src/DI/Helpers.php
+++ b/src/DI/Helpers.php
@@ -165,4 +165,29 @@ class Helpers
 		return $args;
 	}
 
+
+	/**
+	 * Prepend extension name to identifier or service name.
+	 * @param mixed
+	 * @param string
+	 * @return mixed
+	 */
+	public static function prefixServiceName($config, $namespace)
+	{
+		if (is_string($config)) {
+			if (strpos($config, '@extension.') === 0) {
+				$config = '@' . $namespace . '.' . substr($config, 11);
+			}
+		} elseif ($config instanceof Statement) {
+			$config->setEntity(self::prefixServiceName($config->getEntity(), $namespace));
+			$config->arguments = self::prefixServiceName($config->arguments, $namespace);
+		} elseif (is_array($config)) {
+			foreach ($config as $key => &$val) {
+				$val = self::prefixServiceName($val, $namespace);
+			}
+		}
+
+		return $config;
+	}
+
 }

--- a/tests/DI/Compiler.parseServices.namespace.phpt
+++ b/tests/DI/Compiler.parseServices.namespace.phpt
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Test: Nette\DI\Compiler and parseServices.
+ */
+
+use Nette\DI;
+use Tester\Assert;
+
+require __DIR__ . '/../bootstrap.php';
+
+$builder = new DI\ContainerBuilder();
+$config = (new DI\Config\Adapters\NeonAdapter())->load(__DIR__ . '/files/compiler.parseServices.namespace.neon');
+DI\Compiler::parseServices($builder, $config, 'blog');
+
+
+Assert::same('@blog.articles', $builder->getDefinition('blog.comments')->getFactory()->arguments[1]);
+Assert::same('@blog.articles', $builder->getDefinition('blog.articlesList')->getFactory()->arguments[0]);
+Assert::same('@blog.comments', $builder->getDefinition('blog.commentsControl')->getFactory()->arguments[0]->getEntity());

--- a/tests/DI/files/compiler.parseServices.namespace.neon
+++ b/tests/DI/files/compiler.parseServices.namespace.neon
@@ -1,0 +1,7 @@
+services:
+	comments: MyBlog\CommentsModel(@connection, @extension.articles)
+	articlesList:
+		class: MyBlog\Components\ArticlesList(@extension.articles)
+	commentsControl:
+		class: MyBlog\Components\CommentsControl
+		arguments: [@extension.comments()] #factory syntax


### PR DESCRIPTION
ref nette/web-content#377
cc @Majkl578 @greeny 