### PR TITLE
ContainerBuilder::removeAlias() removes aliases

### DIFF
--- a/src/DI/ContainerBuilder.php
+++ b/src/DI/ContainerBuilder.php
@@ -149,6 +149,16 @@ class ContainerBuilder extends Nette\Object
 
 
 	/**
+	 * Removes the specified alias.
+	 * @return void
+	 */
+	public function removeAlias($alias)
+	{
+		unset($this->aliases[$alias]);
+	}
+
+
+	/**
 	 * Gets all service aliases.
 	 * @return array
 	 */

--- a/tests/DI/ContainerBuilder.aliases2.phpt
+++ b/tests/DI/ContainerBuilder.aliases2.phpt
@@ -41,6 +41,22 @@ $builder->addDefinition('service')
 $builder->addAlias('aliased.service', 'service');
 $builder->addAlias('aliased.serviceFactory', 'serviceFactory');
 $builder->addAlias('aliased.serviceFactoryViaClass', 'serviceFactoryViaClass');
+$builder->addAlias('aliased.serviceToRemove', 'service');
+
+Assert::same([
+	'aliased.service' => 'service',
+	'aliased.serviceFactory' => 'serviceFactory',
+	'aliased.serviceFactoryViaClass' => 'serviceFactoryViaClass',
+	'aliased.serviceToRemove' => 'service',
+], $builder->getAliases());
+
+$builder->removeAlias('aliased.serviceToRemove');
+
+Assert::same([
+	'aliased.service' => 'service',
+	'aliased.serviceFactory' => 'serviceFactory',
+	'aliased.serviceFactoryViaClass' => 'serviceFactoryViaClass',
+], $builder->getAliases());
 
 // Access to service definition using alias
 Assert::true($builder->hasDefinition('aliased.service'));


### PR DESCRIPTION
This feature request is similar to the function `removeDefinition` in `ContainerBuilder`. It can be useful to remove aliases as well. For example I am trying to do hot-reload already registered extensions inside of another extensions to add additional configuration. Unfortunately it's not possible without removing aliases (or maybe I don't know how). See [this use case](https://gist.github.com/mrtnzlml/21690953afb9dfad1824#file-compilerextension-php-L47).