### PR TITLE
Check for unused parameter when generating factory

### DIFF
--- a/src/DI/ContainerBuilder.php
+++ b/src/DI/ContainerBuilder.php
@@ -416,6 +416,9 @@ class ContainerBuilder extends Nette\Object
 						throw new ServiceCreationException("Type hint for \${$param->getName()} in $interface::$methodName() doesn't match type hint in $class constructor.");
 					}
 					$def->getFactory()->arguments[$arg->getPosition()] = self::literal('$' . $arg->getName());
+				} elseif (!$def->getSetup()) {
+					$hint = Nette\Utils\ObjectMixin::getSuggestion(array_keys($ctorParams), $param->getName());
+					throw new ServiceCreationException("Unused parameter \${$param->getName()} when implementing method $interface::$methodName()" . ($hint ? ", did you mean \${$hint}?" : '.'));
 				}
 				$paramDef = $hint . ' ' . $param->getName();
 				if ($param->isOptional()) {

--- a/tests/DI/Compiler.generatedFactory.phpt
+++ b/tests/DI/Compiler.generatedFactory.phpt
@@ -238,3 +238,43 @@ Assert::exception(function () {
 	$builder->addDefinition('one')->setImplement('Bad2')->setFactory('Bad1');
 	$builder->generateClasses();
 }, Nette\InvalidStateException::class, 'Type hint for $bar in Bad2::create() doesn\'t match type hint in Bad1 constructor.');
+
+
+
+class Bad3
+{
+	public function __construct($bar)
+	{
+	}
+}
+
+interface Bad4
+{
+	public function create($baz);
+}
+
+Assert::exception(function () {
+	$builder = new DI\ContainerBuilder;
+	$builder->addDefinition('one')->setImplement('Bad4')->setFactory('Bad3');
+	$builder->generateClasses();
+}, Nette\InvalidStateException::class, 'Unused parameter $baz when implementing method Bad4::create(), did you mean $bar?');
+
+
+
+class Bad5
+{
+	public function __construct($xxx)
+	{
+	}
+}
+
+interface Bad6
+{
+	public function create($baz);
+}
+
+Assert::exception(function () {
+	$builder = new DI\ContainerBuilder;
+	$builder->addDefinition('one')->setImplement('Bad6')->setFactory('Bad5');
+	$builder->generateClasses();
+}, Nette\InvalidStateException::class, 'Unused parameter $baz when implementing method Bad6::create().');


### PR DESCRIPTION
Purpose: throw an Exception when you have typo in the name of parameter in factory method (or constructor of factory product).

Related: #60
