### PR TITLE
Add support for @var statement[|statement...]

### DIFF
--- a/src/DI/Extensions/InjectExtension.php
+++ b/src/DI/Extensions/InjectExtension.php
@@ -83,6 +83,10 @@ class InjectExtension extends DI\CompilerExtension
 			$rp = new \ReflectionProperty($class, $name);
 			if (PhpReflection::parseAnnotation($rp, 'inject') !== NULL) {
 				if ($type = PhpReflection::parseAnnotation($rp, 'var')) {
+					if (Nette\Utils\Strings::contains($type, '|')) {
+						list($type) = explode('|', $type); //Use only first statement
+					}
+
 					$type = PhpReflection::expandClassName($type, PhpReflection::getDeclaringClass($rp));
 				}
 				$res[$name] = $type;

--- a/tests/DI/InjectExtension.getInjectProperties().phpt
+++ b/tests/DI/InjectExtension.getInjectProperties().phpt
@@ -71,6 +71,28 @@ namespace C
 	}
 }
 
+namespace D
+{
+	interface DInterface
+	{
+
+	}
+
+	class DInjected implements DInterface
+	{
+
+	}
+
+	class DClass
+	{
+		/** @var DInterface|DInjected @inject */
+		public $var1;
+
+		/** @var DInjected|DInterface @inject */
+		public $var2;
+	}
+}
+
 namespace
 {
 	use Nette\DI\Extensions\InjectExtension;
@@ -98,4 +120,9 @@ namespace
 		'var3' => 'C\CInjected',
 		'var4' => 'C\CInjected',
 	], InjectExtension::getInjectProperties('C\CClass'));
+
+	Assert::same([
+		'var1' => 'D\DInterface',
+		'var2' => 'D\DInjected',
+	], InjectExtension::getInjectProperties('D\DClass'));
 }


### PR DESCRIPTION
Add possibility use IDE code completion based on PhpDoc

```php
class FooPresenter extends UI\Presenter {
  /** @var Nette\Mail\IMailer|Nette\Mail\SmtpMailer @inject */
  public $mailer;
}
```