### PR TITLE
Fix BC break in Statement and ServiceDefinition

### DIFF
--- a/src/DI/ServiceDefinition.php
+++ b/src/DI/ServiceDefinition.php
@@ -12,6 +12,10 @@ use Nette;
 
 /**
  * Definition used by ContainerBuilder.
+ *
+ * @property $class
+ * @property $factory
+ * @property-read $entity
  */
 class ServiceDefinition
 {

--- a/src/DI/Statement.php
+++ b/src/DI/Statement.php
@@ -12,6 +12,8 @@ use Nette;
 
 /**
  * Assignment or calling statement.
+ *
+ * @property $entity
  */
 class Statement
 {


### PR DESCRIPTION
```
E_USER_DEPRECATED: Missing annotation @property for Nette\DI\Statement::$entity
```

`$statement->entity` is commonly used by extensions so it's probably not a good idea to make this BC break before 3.0 (and even there it's questionable).