### PR TITLE
Compiler: add getExtension method

### DIFF
--- a/src/DI/Compiler.php
+++ b/src/DI/Compiler.php
@@ -70,6 +70,25 @@ class Compiler
 
 
 	/**
+	 * @param string $class
+	 * @param bool $need
+	 * @return CompilerExtension
+	 */
+	public function getExtension($class, $need = true)
+	{
+		$extensions = $this->compiler->getExtensions($class);
+		$count = count($extensions);
+		if ($count > 1) {
+			throw new \Nette\Utils\AssertionException("Extension '$class' is installed $count times.");
+		}
+		if ($count < 1 && $need) {
+			throw new \Nette\Utils\AssertionException("Extension '$class' is not installed.");
+		}
+		return $count === 1 ? reset($extensions) : null;
+	}
+
+
+	/**
 	 * @return ContainerBuilder
 	 */
 	public function getContainerBuilder()

--- a/src/DI/Compiler.php
+++ b/src/DI/Compiler.php
@@ -76,7 +76,7 @@ class Compiler
 	 */
 	public function getExtension($class, $need = true)
 	{
-		$extensions = $this->compiler->getExtensions($class);
+		$extensions = $this->getExtensions($class);
 		$count = count($extensions);
 		if ($count > 1) {
 			throw new \Nette\Utils\AssertionException("Extension '$class' is installed $count times.");


### PR DESCRIPTION
In some cases (like Kdyby/Doctrine) there is a need for an extension to be configurable not only by config.neon but by other extensions as well. We have been using [this concept](https://forum.nette.org/en/18888-extending-extensions-solid-modular-concept) from @fprochazka for years now. The problem with this approach is that it creates a hard dependency - for example an extension which wants to configure `Kdyby\Doctrine\DI\OrmExtension` has to implement `Kdyby\Doctrine\DI\IEntityProvider`. That of course creates a hard depencency on Kdyby/Doctrine package which is not always desired.

The other (and in my opinion better) approach is to provide a public method which can be called by other extensions. There is only one small problem - while the other extension can access OrmExtension, it can't do so easily:

```php
    public function loadConfiguration()
    {
        $extensions = $this->compiler->getExtensions(OrmExtension::class);
        $extension = reset($extensions);
        // Some condition and exception if $extension is empty
        $extension->thePublicMethod($some, $arguments);
    }
```

Unfortunately this doesn't look good at all so I'd like to add one simple method to make this easier.