### PR TITLE
PhpReflection::getParameterType() can handle PHP 7.1 nullable types

### DIFF
--- a/src/DI/PhpReflection.php
+++ b/src/DI/PhpReflection.php
@@ -58,7 +58,9 @@ class PhpReflection
 	 */
 	public static function getParameterType(\ReflectionParameter $param)
 	{
-		if (PHP_VERSION_ID >= 70000) {
+		if (PHP_VERSION_ID >= 70100) {
+			return $param->hasType() ? $param->getType()->getName() : NULL;
+		} elseif (PHP_VERSION_ID >= 70000) {
 			return $param->hasType() ? (string) $param->getType() : NULL;
 		} elseif ($param->isArray() || $param->isCallable()) {
 			return $param->isArray() ? 'array' : 'callable';

--- a/tests/DI/PhpReflection.getParameterType.php71.phpt
+++ b/tests/DI/PhpReflection.getParameterType.php71.phpt
@@ -2,6 +2,7 @@
 
 /**
  * Test: Nette\DI\PhpReflection::getParameterType
+ * @phpversion >= 7.1
  */
 
 use Nette\DI\PhpReflection;
@@ -15,7 +16,7 @@ use Test\B; // for testing purposes
 
 class A
 {
-	function method(Undeclared $undeclared, B $b, array $array, callable $callable, $none, B $nullable = NULL)
+	function method(?Undeclared $undeclared, ?B $b, ?array $array, ?callable $callable, $none, ?B $nullable = NULL)
 	{}
 }
 


### PR DESCRIPTION
Nullable parameter types are prefixed by `?` in Reflection in PHP 7.1 which causes that Nette autowiring doesn't work. Even though this behaviour has changed many times in PHP 7.1 ( https://github.com/php/php-src/commit/622d2f41d1cdb597f4fafecaaacf66e238742bd4 , https://github.com/php/php-src/commit/8855a2ce76e8bfba1d2eea1345c765fde7a9a441 , https://github.com/php/php-src/commit/f4e68a3968429757719c600ce16913ab09539f0d ) this fix uses new preferred way ReflectionNamedType::getName() which looks pretty stable.