### PR TITLE
Config\Loader: allow absolute paths in includes section

### DIFF
--- a/src/DI/Config/Loader.php
+++ b/src/DI/Config/Loader.php
@@ -56,7 +56,10 @@ class Loader
 		if (isset($data[self::INCLUDES_KEY])) {
 			Validators::assert($data[self::INCLUDES_KEY], 'list', "section 'includes' in file '$file'");
 			foreach ($data[self::INCLUDES_KEY] as $include) {
-				$merged = Helpers::merge($this->load(dirname($file) . '/' . $include), $merged);
+				if (!preg_match('#([a-z]:)?[/\\\\]#Ai', $include)) {
+					$include = dirname($file) . '/' . $include;
+				}
+				$merged = Helpers::merge($this->load($include), $merged);
 			}
 		}
 		unset($data[self::INCLUDES_KEY]);

--- a/tests/DI/Loader.include.phpt
+++ b/tests/DI/Loader.include.phpt
@@ -18,12 +18,14 @@ Assert::same([
 	'files/loader.includes.neon',
 	'files/loader.includes.child.ini',
 	'files/loader.includes.child.php',
+	__DIR__ . DIRECTORY_SEPARATOR . 'files/loader.includes.grandchild.neon',
 ], $config->getDependencies());
 
 Assert::same([
 	'parameters' => [
 		'me' => [
 			'loader.includes.child.ini',
+			'loader.includes.grandchild.neon',
 			'loader.includes.child.php',
 		],
 		'scalar' => 1,

--- a/tests/DI/files/loader.includes.child.php
+++ b/tests/DI/files/loader.includes.child.php
@@ -7,4 +7,8 @@ return [
 		'list' => [5, 6],
 		'force' => [5, 6],
 	],
+
+	'includes' => [
+		__DIR__ . '/loader.includes.grandchild.neon',
+	],
 ];

--- a/tests/DI/files/loader.includes.grandchild.neon
+++ b/tests/DI/files/loader.includes.grandchild.neon
@@ -1,0 +1,2 @@
+parameters:
+	me: [loader.includes.grandchild.neon]


### PR DESCRIPTION
I'm developing a system-wide application. Many `neon` configurations files in `/etc/app` and `/usr/lib/app/module-xxx/config.neon`. Would be more comfortable to work with absolute paths.