### PR TITLE
[ContainerBuilder] getDefinitionByType() method added

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,6 +1,6 @@
-* [x] bug
-* [ ] enhancement
-* version: <!-- exact release version. PHP version, OS, web server if relevant -->
+- bug report? yes/no
+- feature request? yes/no
+- version: ?.?.? <!-- exact release version, for bug reports -->
 
 ### Description
 ...

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
-* [ ] bug fix   <!-- #issue numbers, if any -->
-* [ ] enhancement
-* [ ] BC breaks
-* [ ] doc PR nette/docs#...  <!-- highly welcome, see https://nette.org/en/writing -->
+- bug fix? yes/no   <!-- #issue numbers, if any -->
+- new feature? yes/no
+- BC break? yes/no
+- doc PR: nette/docs#???  <!-- highly welcome, see https://nette.org/en/writing -->
 
 <!--
 Describe your changes here to communicate to the maintainers why we should accept this pull request.

--- a/src/DI/ContainerBuilder.php
+++ b/src/DI/ContainerBuilder.php
@@ -240,6 +240,22 @@ class ContainerBuilder
 
 
 	/**
+	 * Gets the service definition of the specified type.
+	 * @param  string
+	 * @return ServiceDefinition|NULL
+	 */
+	public function getDefinitionByType($class)
+	{
+		$definitionName = $this->getByType($class);
+		if (!$definitionName) {
+			throw new MissingServiceException("Service of type '$class' not found.");
+		}
+
+		return $this->getDefinition($definitionName);
+	}
+
+
+	/**
 	 * Gets the service names and definitions of the specified type.
 	 * @param  string
 	 * @return ServiceDefinition[]

--- a/tests/DI/ContainerBuilder.getDefinitionByType.phpt
+++ b/tests/DI/ContainerBuilder.getDefinitionByType.phpt
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Test: Nette\DI\ContainerBuilder::getDefinitionByType()
+ */
+
+use Nette\DI;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+$builder = new DI\ContainerBuilder;
+$definitionOne = $builder->addDefinition('one')
+	->setClass(stdClass::class);
+
+$builder->addDefinition('two')
+	->setClass(SplFileInfo::class);
+
+$builder->addDefinition('three')
+	->setClass(SplFileInfo::class);
+
+
+$definition = $builder->getDefinitionByType(stdClass::class);
+Assert::same($definitionOne, $definition);
+
+Assert::exception(function () use ($builder) {
+	$builder->getDefinitionByType('unknown');
+}, Nette\DI\MissingServiceException::class, "Service of type 'unknown' not found.");
+
+Assert::exception(function () use ($builder) {
+	$builder->getDefinitionByType(SplFileInfo::class);
+}, Nette\DI\ServiceCreationException::class, 'Multiple services of type SplFileInfo found: two, three');


### PR DESCRIPTION
- bug fix? no #130
- new feature? yes
- BC break? no

All is described in the issue: #130 

Behavior is compatible with with `getDefiniton()` - exception is thrown when not found.
This method is called in cases where Definition is required.

