### PR TITLE
Compiler: loadDefinitions is called for each config separately

### DIFF
--- a/src/DI/Compiler.php
+++ b/src/DI/Compiler.php
@@ -29,6 +29,9 @@ class Compiler
 	/** @var array */
 	private $config = [];
 
+	/** @var array */
+	private $serviceConfigs = [];
+
 	/** @var DependencyChecker */
 	private $dependencies;
 
@@ -96,6 +99,9 @@ class Compiler
 	 */
 	public function addConfig(array $config)
 	{
+		if (isset($config['services'])) {
+			$this->serviceConfigs[] = $config['services'];
+		}
 		$this->config = Config\Helpers::merge($config, $this->config);
 		return $this;
 	}
@@ -219,8 +225,8 @@ class Compiler
 	/** @internal */
 	public function processServices()
 	{
-		if (isset($this->config['services'])) {
-			self::loadDefinitions($this->builder, $this->config['services']);
+		foreach ($this->serviceConfigs as $config) {
+			self::loadDefinitions($this->builder, $config);
 		}
 	}
 

--- a/tests/DI/Compiler.configOverride.phpt
+++ b/tests/DI/Compiler.configOverride.phpt
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Test: Overriding/modifying service definition in another config
+ */
+
+declare(strict_types=1);
+
+use Nette\DI;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+class Ipsum
+{
+	function __construct(...$args)
+	{
+		Notes::add(__METHOD__ . ' ' . implode(' ' , $args));
+	}
+}
+
+$class = 'Container' . md5((string) lcg_value());
+$compiler = new DI\Compiler;
+$compiler->addConfig([
+	'services' => [
+		's1' => 'Ipsum',
+		's2' => ['class' => 'Ipsum'],
+	],
+]);
+$compiler->addConfig([
+	'services' => [
+		's1' => ['arguments' => [2]],
+		's2' => ['class' => 'Ipsum', 'alteration' => TRUE,],
+	],
+]);
+
+$code = $compiler->setClassName($class)
+	->compile();
+
+file_put_contents(TEMP_DIR . '/code.php', "<?php\n\n$code");
+require TEMP_DIR . '/code.php';
+
+/** @var DI\Container $container */
+$container = new $class();
+
+Assert::type(Ipsum::class, $container->getService('s1'));
+Assert::same([
+	'Ipsum::__construct 2',
+], Notes::fetch());
+
+$compiler->addConfig([
+	'services' => [
+		's3' => ['class' => 'Ipsum', 'alteration' => TRUE,],
+	],
+]);
+
+Assert::exception(function () use ($compiler, $class) {
+	$compiler->setClassName($class)
+		->compile();
+}, DI\ServiceCreationException::class, "Service 's3': missing original definition for alteration.");


### PR DESCRIPTION
- bug fix? yes
- new feature? yes
- BC break? yes

When you have multiple config files, things like alternation does not work. 
Or if you have `services: [Foo]` (without `class` key) in one config and you try to add `setup` in another config, it fails.

This may cause a bc break when a service definition in the first config is incomplete.
