### PR TITLE
DI\Compiler: use IExtensionsExtension while processing extensions

### DIFF
--- a/src/DI/Compiler.php
+++ b/src/DI/Compiler.php
@@ -185,7 +185,7 @@ class Compiler
 		$this->config = Helpers::expand(array_diff_key($this->config, self::$reserved), $this->builder->parameters)
 			+ array_intersect_key($this->config, self::$reserved);
 
-		foreach ($first = $this->getExtensions(Extensions\ExtensionsExtension::class) as $name => $extension) {
+		foreach ($first = $this->getExtensions(Extensions\IExtensionsExtension::class) as $name => $extension) {
 			$extension->setConfig($this->config[$name] ?? []);
 			$extension->loadConfiguration();
 		}

--- a/src/DI/Extensions/ExtensionsExtension.php
+++ b/src/DI/Extensions/ExtensionsExtension.php
@@ -15,7 +15,7 @@ use Nette;
 /**
  * Enables registration of other extensions in $config file
  */
-final class ExtensionsExtension extends Nette\DI\CompilerExtension
+final class ExtensionsExtension extends Nette\DI\CompilerExtension implements IExtensionsExtension
 {
 
 	public function loadConfiguration()

--- a/src/DI/Extensions/IExtensionsExtension.php
+++ b/src/DI/Extensions/IExtensionsExtension.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (https://nette.org)
+ * Copyright (c) 2004 David Grudl (https://davidgrudl.com)
+ */
+
+declare(strict_types=1);
+
+namespace Nette\DI\Extensions;
+
+
+/**
+ * Enables registration of other extensions in $config file
+ */
+interface IExtensionsExtension
+{
+
+}

--- a/tests/DI/ExtensionsExtension.interface.phpt
+++ b/tests/DI/ExtensionsExtension.interface.phpt
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Test: Nette\DI\Compiler and ExtensionsExtension.
+ */
+
+declare(strict_types=1);
+
+use Nette\DI;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+class FooExtension extends DI\CompilerExtension
+{
+	function loadConfiguration()
+	{
+		$this->getContainerBuilder()->parameters['registeredExtensions'] = array_keys($this->compiler->getExtensions());
+		$this->getContainerBuilder()->parameters[$this->name] = $this->getConfig();
+	}
+}
+
+
+class UppercaseExtensionExtension extends DI\CompilerExtension implements DI\Extensions\IExtensionsExtension
+{
+	function loadConfiguration()
+	{
+		foreach ($this->getConfig() as $name => $class) {
+			$this->compiler->addExtension('__' . strtoupper($name), new $class);
+		}
+	}
+}
+
+
+$compiler = new DI\Compiler;
+$compiler->addExtension('extensions', new Nette\DI\Extensions\ExtensionsExtension);
+$compiler->addExtension('customExtensions', new UppercaseExtensionExtension);
+$container = createContainer($compiler, '
+extensions:
+	foo: FooExtension
+
+customExtensions:
+	foo: FooExtension
+
+foo:
+	key: value
+
+__FOO:
+	KEY: VALUE
+');
+
+
+Assert::same([
+	'registeredExtensions' => ['extensions', 'customExtensions', 'foo', '__FOO'],
+	'foo' => ['key' => 'value'],
+	'__FOO' => ['KEY' => 'VALUE'],
+], $container->parameters);


### PR DESCRIPTION
This feature adds possibility to replace ExtensionsExtension with
custom implementation of IExtensionsExtension. Nette\DI\Compiler uses
this interface instead of direct implementor.

- bug fix? **no**   <!-- #issue numbers, if any -->
- new feature? **yes**
- BC break? **no**
- doc PR: *is it needed?*  <!-- highly welcome, see https://nette.org/en/writing -->

<!--
Describe your changes here to communicate to the maintainers why we should accept this pull request.

Please add new tests to show the fix or feature works. And take a moment to read the contributing guide https://nette.org/en/contributing

Thanks for contributing to Nette!
-->
