### PR TITLE
Compiler::loadDefinitions: allow to get to existing service by class

### DIFF
--- a/src/DI/Compiler.php
+++ b/src/DI/Compiler.php
@@ -257,7 +257,13 @@ class Compiler
 	public static function loadDefinitions(ContainerBuilder $builder, array $services, string $namespace = NULL)
 	{
 		foreach ($services as $name => $def) {
-			if ((string) (int) $name === (string) $name) {
+			if (is_string($name) && preg_match('#^@\w*[\\\][\w\\\]+\z#', $name)) {
+				$service = substr($name, 1);
+				$name = $builder->getByType($service);
+				if (!$name) {
+					throw new ServiceCreationException("Reference to missing service of type $service.");
+				}
+			} elseif ((string) (int) $name === (string) $name) {
 				$postfix = $def instanceof Statement && is_string($def->getEntity()) ? '.' . $def->getEntity() : (is_scalar($def) ? ".$def" : '');
 				$name = (count($builder->getDefinitions()) + 1) . preg_replace('#\W+#', '_', $postfix);
 			} elseif ($namespace) {

--- a/tests/DI/Compiler.services.byClass.phpt
+++ b/tests/DI/Compiler.services.byClass.phpt
@@ -22,6 +22,15 @@ class Lorem
 
 class Ipsum
 {
+	public $value;
+
+
+	public function __construct($value)
+	{
+		$this->value = $value;
+	}
+
+
 	static function foo()
 	{
 	}
@@ -36,16 +45,20 @@ services:
 		class: Lorem(@\Ipsum)
 
 	two:
-		class: Ipsum
+		class: Ipsum(1)
 		setup:
 			- @\Ipsum::foo()
 
 	four: @\Lorem
+
+	@\Ipsum:
+		arguments: [2]
 ');
 
 
 Assert::type(Lorem::class, $container->getService('one'));
 Assert::type(Ipsum::class, $container->getService('two'));
+Assert::same(2, $container->getService('two')->value);
 Assert::type(Lorem::class, $container->getService('three'));
 Assert::same($container->getService('one'), $container->getService('three'));
 Assert::type(Lorem::class, $container->getService('four'));


### PR DESCRIPTION
- bug fix? no
- new feature? yes
- BC break? no

it is useful when you want to modify anonymous service in your local.neon