### PR TITLE
ServiceDefinition::setClass() parameter $args is deprecated (BC break)

### DIFF
--- a/src/DI/ServiceDefinition.php
+++ b/src/DI/ServiceDefinition.php
@@ -61,12 +61,15 @@ final class ServiceDefinition
 	/**
 	 * @return static
 	 */
-	public function setClass($class, array $args = [])
+	public function setClass($class)
 	{
 		($this->notifier)();
 		$this->class = $class;
-		if ($args) {
-			$this->setFactory($class, $args);
+		if (func_num_args() > 1) {
+			trigger_error(__METHOD__ . '() second parameter $args is deprecated, use setFactory()', E_USER_DEPRECATED);
+			if ($args = func_get_arg(1)) {
+				$this->setFactory($class, $args);
+			}
 		}
 		return $this;
 	}

--- a/tests/DI/ServiceDefinition.phpt
+++ b/tests/DI/ServiceDefinition.phpt
@@ -27,14 +27,18 @@ test(function () {
 
 test(function () {
 	$def = new ServiceDefinition;
-	$def->setClass('Class', []); // misused
+	Assert::error(function () use ($def) {
+		$def->setClass('Class', []);
+	}, E_USER_DEPRECATED);
 	Assert::same('Class', $def->getClass());
 	Assert::null($def->getFactory());
 });
 
 test(function () {
 	$def = new ServiceDefinition;
-	$def->setClass('Class', [1, 2]); // misused
+	Assert::error(function () use ($def) {
+		$def->setClass('Class', [1, 2]);
+	}, E_USER_DEPRECATED);
 	Assert::same('Class', $def->getClass());
 	Assert::equal(new Statement('Class', [1, 2]), $def->getFactory());
 });


### PR DESCRIPTION
- bug fix? no   <!-- #issue numbers, if any -->
- new feature? no
- BC break? yes

`class` vs `factory` should be better distinguished, it is difficult to merge more configs where these options are mixed. Related to #39 