### PR TITLE
In case of malformed dependencies provide type hint for calling service

### DIFF
--- a/src/DI/ContainerBuilder.php
+++ b/src/DI/ContainerBuilder.php
@@ -549,7 +549,7 @@ class ContainerBuilder
 				$def->setSetup($setups);
 
 			} catch (\Exception $e) {
-				throw new ServiceCreationException("Service '$name': " . $e->getMessage(), 0, $e);
+				throw new ServiceCreationException("Service '$name' (type of $entity): " . $e->getMessage(), 0, $e);
 
 			} finally {
 				$this->currentService = NULL;

--- a/tests/DI/ContainerBuilder.autowiring.novalue.phpt
+++ b/tests/DI/ContainerBuilder.autowiring.novalue.phpt
@@ -24,7 +24,7 @@ Assert::exception(function () {
 	$builder = new DI\ContainerBuilder;
 	$builder->addDefinition('foo')->setClass('Foo');
 	$container = createContainer($builder);
-}, Nette\DI\ServiceCreationException::class, "Service 'foo': Parameter \$x in Foo::__construct() has no class type hint or default value, so its value must be specified.");
+}, Nette\DI\ServiceCreationException::class, "Service 'foo' (type of Foo): Parameter \$x in Foo::__construct() has no class type hint or default value, so its value must be specified.");
 
 
 class Bar
@@ -38,4 +38,4 @@ Assert::exception(function () {
 	$builder = new DI\ContainerBuilder;
 	$builder->addDefinition('foo')->setClass('Bar');
 	$container = createContainer($builder);
-}, Nette\DI\ServiceCreationException::class, "Service 'foo': Parameter \$x in Bar::__construct() has no class type hint or default value, so its value must be specified.");
+}, Nette\DI\ServiceCreationException::class, "Service 'foo' (type of Bar): Parameter \$x in Bar::__construct() has no class type hint or default value, so its value must be specified.");

--- a/tests/DI/ContainerBuilder.error.phpt
+++ b/tests/DI/ContainerBuilder.error.phpt
@@ -20,7 +20,7 @@ $builder->addDefinition('one')
 
 Assert::exception(function () use ($builder) {
 	$builder->complete();
-}, Nette\InvalidStateException::class, "Service 'one': Expected function, method or property name, '1234' given.");
+}, Nette\InvalidStateException::class, "Service 'one' (type of stdClass): Expected function, method or property name, '1234' given.");
 
 
 
@@ -53,4 +53,4 @@ $builder->addDefinition('one')
 
 Assert::exception(function () use ($builder) {
 	$builder->complete();
-}, Nette\InvalidStateException::class, "Service 'one': Missing argument for \$prop[].");
+}, Nette\InvalidStateException::class, "Service 'one' (type of stdClass): Missing argument for \$prop[].");

--- a/tests/DI/ContainerBuilder.factory.error.phpt
+++ b/tests/DI/ContainerBuilder.factory.error.phpt
@@ -147,7 +147,7 @@ Assert::exception(function () {
 	$builder = new DI\ContainerBuilder;
 	$builder->addDefinition('one')->setClass('Bad8');
 	$builder->complete();
-}, Nette\InvalidStateException::class, "Service 'one': Class Bad8 has private constructor.");
+}, Nette\InvalidStateException::class, "Service 'one' (type of Bad8): Class Bad8 has private constructor.");
 
 
 class Good
@@ -160,13 +160,13 @@ Assert::exception(function () {
 	$builder = new DI\ContainerBuilder;
 	$builder->addDefinition('one')->setFactory('Good', [new Statement('Bad')]);
 	$builder->complete();
-}, Nette\InvalidStateException::class, "Service 'one': Class Bad not found.");
+}, Nette\InvalidStateException::class, "Service 'one' (type of Good): Class Bad not found.");
 
 Assert::exception(function () {
 	$builder = new DI\ContainerBuilder;
 	$builder->addDefinition('one')->setFactory('Good', [new Statement('Bad8')]);
 	$builder->complete();
-}, Nette\InvalidStateException::class, "Service 'one': Class Bad8 has private constructor.");
+}, Nette\InvalidStateException::class, "Service 'one' (type of Good): Class Bad8 has private constructor.");
 
 
 abstract class Bad9
@@ -179,4 +179,4 @@ Assert::exception(function () {
 	$builder = new DI\ContainerBuilder;
 	$builder->addDefinition('one')->setClass('Bad9');
 	$builder->complete();
-}, Nette\InvalidStateException::class, "Service 'one': Class Bad9 is abstract.");
+}, Nette\InvalidStateException::class, "Service 'one' (type of Bad9): Class Bad9 is abstract.");


### PR DESCRIPTION
- bug fix? no
- new feature? no
- BC break? no

In case of malformed dependencies I got message such `"Service '94': ..."`. Now I get `"Service '94' (type of App\Presenter\HomePagePresenter): ..."`
