### PR TITLE
generated factories: fix return type

### DIFF
--- a/src/DI/PhpGenerator.php
+++ b/src/DI/PhpGenerator.php
@@ -10,11 +10,10 @@ declare(strict_types=1);
 namespace Nette\DI;
 
 use Nette;
-use Nette\Utils\Validators;
 use Nette\Utils\Strings;
 use Nette\PhpGenerator\Helpers as PhpHelpers;
 use Nette\PhpGenerator\PhpLiteral;
-use ReflectionClass;
+use Nette\Utils\Reflection;
 
 
 /**
@@ -150,10 +149,12 @@ class PhpGenerator
 			->addParameter('container')
 				->setTypeHint($this->className);
 
+		$rm = new \ReflectionMethod($def->getImplement(), $def->getImplementMode());
+
 		$factoryClass->addMethod($def->getImplementMode())
 			->setParameters($this->convertParameters($def->parameters))
 			->setBody(str_replace('$this', '$this->container', $code))
-			->setReturnType($def->getClass());
+			->setReturnType(Reflection::getReturnType($rm) ?: $def->getClass());
 
 		return 'return new class ($this) ' . $factoryClass . ';';
 	}

--- a/tests/DI/Compiler.generatedFactory.returnTypes.phpt
+++ b/tests/DI/Compiler.generatedFactory.returnTypes.phpt
@@ -29,6 +29,11 @@ class Article
 	}
 }
 
+class FooArticle extends Article
+{
+
+}
+
 $compiler = new DI\Compiler;
 $container = createContainer($compiler, 'files/compiler.generatedFactory.returnTypes.neon');
 
@@ -40,4 +45,10 @@ Assert::same('lorem-ipsum', $article->title);
 Assert::type(IArticleFactory::class, $container->getService('article2'));
 $article = $container->getService('article2')->create('lorem-ipsum');
 Assert::type(Article::class, $article);
+Assert::same('lorem-ipsum', $article->title);
+
+
+Assert::type(IArticleFactory::class, $container->getService('article3'));
+$article = $container->getService('article3')->create('lorem-ipsum');
+Assert::type(FooArticle::class, $article);
 Assert::same('lorem-ipsum', $article->title);

--- a/tests/DI/files/compiler.generatedFactory.returnTypes.neon
+++ b/tests/DI/files/compiler.generatedFactory.returnTypes.neon
@@ -9,3 +9,7 @@ services:
 		implement: IArticleFactory
 		arguments: [%title%]
 		parameters: [title]
+
+	article3:
+		implement: IArticleFactory
+		factory: FooArticle


### PR DESCRIPTION
- bug fix? yes
- new feature? no
- BC break? no

because php does not support return type covariance