### PR TITLE
fixed including of paths with scheme in config loader

### DIFF
--- a/src/DI/Config/Loader.php
+++ b/src/DI/Config/Loader.php
@@ -48,7 +48,7 @@ class Loader
 		if (isset($data[self::INCLUDES_KEY])) {
 			Validators::assert($data[self::INCLUDES_KEY], 'list', "section 'includes' in file '$file'");
 			foreach ($data[self::INCLUDES_KEY] as $include) {
-				if (!preg_match('#([a-z]:)?[/\\\\]#Ai', $include)) {
+				if (!preg_match('#([a-z]+:)?[/\\\\]#Ai', $include)) {
 					$include = dirname($file) . '/' . $include;
 				}
 				$merged = Helpers::merge($this->load($include), $merged);


### PR DESCRIPTION
- bug fix? yes
- new feature? no
- BC break? no

Including a config in the following way doesn't work

```yaml
includes:
    - phar://phpstan.phar/vendor/phpstan/phpstan-doctrine/extension.neon
```

