### PR TITLE
DIExtension: drop unused accessors

### DIFF
--- a/src/DI/Extensions/DIExtension.php
+++ b/src/DI/Extensions/DIExtension.php
@@ -19,7 +19,6 @@ final class DIExtension extends Nette\DI\CompilerExtension
 {
 	public $defaults = [
 		'debugger' => true,
-		'accessors' => false,
 		'excluded' => [],
 		'parentClass' => null,
 	];


### PR DESCRIPTION
- bug fix? no
- new feature? no
- BC break? maybe

---

I've dropped unused configuration option `accessors`.