### PR TITLE
Container::getByType fixed phpdoc return typehint

### DIFF
--- a/src/DI/Container.php
+++ b/src/DI/Container.php
@@ -183,7 +183,7 @@ class Container
 	/**
 	 * Resolves service by type.
 	 * @param  bool  $throw  exception if service doesn't exist?
-	 * @return object  service or null
+	 * @return object|null service
 	 * @throws MissingServiceException
 	 */
 	public function getByType(string $type, bool $throw = true)
@@ -199,6 +199,8 @@ class Container
 		} elseif ($throw) {
 			throw new MissingServiceException("Service of type $type not found.");
 		}
+
+		return null;
 	}
 
 


### PR DESCRIPTION
- bug fix
- BC break? no

Container::getByType really returns null (previously "returned" void).