### PR TITLE
DIExtension: service name tagged with run cast to string

### DIFF
--- a/src/DI/Extensions/DIExtension.php
+++ b/src/DI/Extensions/DIExtension.php
@@ -62,7 +62,7 @@ final class DIExtension extends Nette\DI\CompilerExtension
 		}
 
 		foreach (array_filter($builder->findByTag('run')) as $name => $on) {
-			$initialize->addBody('$this->getService(?);', [$name]);
+			$initialize->addBody('$this->getService(?);', [(string) $name]);
 		}
 	}
 }

--- a/tests/DI/DIExtension.run.phpt
+++ b/tests/DI/DIExtension.run.phpt
@@ -20,6 +20,7 @@ $loader = new DI\Config\Loader;
 $config = $loader->load(Tester\FileMock::create('
 services:
 	std: {factory: stdClass, tags: [run]}
+	- {factory: stdClass, tags: [run]}
 ', 'neon'));
 
 eval($compiler->addConfig($config)->setClassName('Container1')->compile());


### PR DESCRIPTION
- bug fix  <!-- #issue numbers, if any -->
- BC break? no

Following code 
```yaml
services:
    - {factory: stdClass, tags: [run]}
```
causes TypeError: ` TypeError: Argument 1 passed to Nette\DI\Container::getService() must be of the type string, integer given`
