### PR TITLE
Feature set argument

### DIFF
--- a/src/DI/ServiceDefinition.php
+++ b/src/DI/ServiceDefinition.php
@@ -142,6 +142,21 @@ final class ServiceDefinition
 
 
 	/**
+	 * @param  mixed  $key
+	 * @param  mixed  $value
+	 * @return static
+	 */
+	public function setArgument($key, $value)
+	{
+		if (!$this->factory) {
+			$this->factory = new Statement($this->type);
+		}
+		$this->factory->arguments[$key] = $value;
+		return $this;
+	}
+
+
+	/**
 	 * @param  Statement[]  $setup
 	 * @return static
 	 */

--- a/tests/DI/ServiceDefinition.phpt
+++ b/tests/DI/ServiceDefinition.phpt
@@ -55,6 +55,20 @@ test(function () {
 });
 
 test(function () {
+	// Test with factory being previously set.
+	$def1 = new ServiceDefinition;
+	$def1->setFactory('Class', ['foo', 'bar']);
+	$def1->setArgument(1, 'new');
+	Assert::equal(new Statement('Class', ['foo', 'new']), $def1->getFactory());
+
+	// Test with factory being set implicitly.
+	$def2 = new ServiceDefinition;
+	$def2->setArgument(1, 'new');
+	$def2->setArgument(2, 'bar');
+	Assert::equal(new Statement(null, [1 => 'new', 2 => 'bar']), $def2->getFactory());
+});
+
+test(function () {
 	$def = new ServiceDefinition;
 	$def->setFactory('Class', [1, 2]);
 	Assert::null($def->getType());

--- a/tests/DI/ServiceDefinition.phpt
+++ b/tests/DI/ServiceDefinition.phpt
@@ -52,6 +52,10 @@ test(function () {
 	$def->setArguments([1, 2]);
 	Assert::null($def->getType());
 	Assert::equal(new Statement('Class', [1, 2]), $def->getFactory());
+
+	// Demonstrate that setArguments call will always replace arguments.
+	$def->setArguments([1 => 200]);
+	Assert::equal(new Statement('Class', [1 => 200]), $def->getFactory());
 });
 
 test(function () {


### PR DESCRIPTION
- new feature, see issue #171
- BC break: no
- doc PR: not at this time since the original `setArguments()` method wasn't currently mentioned

As discussed in the linked issue, now it is possible to modify individual arguments of services' factories in an easier and concise way. It may be useful when the goal is to modify only certain arguments of services created by another extension, while keeping other arguments intact.
