### PR TITLE
ContainerBuilder: set caused by exception

### DIFF
--- a/src/DI/ContainerBuilder.php
+++ b/src/DI/ContainerBuilder.php
@@ -487,7 +487,7 @@ class ContainerBuilder
 			if (isset($e) || ($refClass && (!$reflection->isPublic()
 				|| ($refClass->isTrait() && !$reflection->isStatic())
 			))) {
-				throw new ServiceCreationException(sprintf("Method %s() used in service '%s' is not callable.", Nette\Utils\Callback::toString($entity), $serviceName));
+				throw new ServiceCreationException(sprintf("Method %s() used in service '%s' is not callable.", Nette\Utils\Callback::toString($entity), $serviceName), 0, $e ?? null);
 			}
 			$this->addDependency($reflection);
 


### PR DESCRIPTION
- bug fix? yes
- BC break? no

Added link to previous exception when service creation failed due to reflection exception - because for example class not found.
