### PR TITLE
autowiring via Service[] (WIP)

### DIFF
--- a/src/DI/Autowiring.php
+++ b/src/DI/Autowiring.php
@@ -189,6 +189,16 @@ class Autowiring
 					$optCount = 0;
 				}
 
+			} elseif (
+				$container instanceof Resolver
+				&& $method instanceof \ReflectionMethod
+				&& $parameter->isArray()
+				&& preg_match('#@param[ \t]+([\w\\\\]+)\[\][ \t]+\$' . $paramName . '#', (string) $method->getDocComment(), $m)
+				&& ($type = Reflection::expandClassName($m[1], $method->getDeclaringClass()))
+				&& (class_exists($type) || interface_exists($type))
+			) {
+				$res[$num] = $container->findByType($type);
+
 			} elseif (($type && $parameter->allowsNull()) || $parameter->isOptional() || $parameter->isDefaultValueAvailable()) {
 				// !optional + defaultAvailable = func($a = null, $b) since 5.4.7
 				// optional + !defaultAvailable = i.e. Exception::__construct, mysqli::mysqli, ...

--- a/tests/DI/ContainerBuilder.autowiring.type[].phpt
+++ b/tests/DI/ContainerBuilder.autowiring.type[].phpt
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * Test: Nette\DI\ContainerBuilder and typehint Service[].
+ */
+
+declare(strict_types=1);
+
+use Nette\DI;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+class Foo
+{
+	public $bars;
+	public $foos;
+	public $strings;
+
+
+	/**
+	 * @param Service[] $bars
+	 * @param Foo[] $foos
+	 * @param string[] $strings
+	 */
+	public function __construct(array $bars = [], array $foos = null, array $strings = ['default'])
+	{
+		$this->bars = $bars;
+		$this->foos = $foos;
+		$this->strings = $strings;
+	}
+}
+
+class Service
+{
+}
+
+class ServiceChild extends Service
+{
+}
+
+
+$builder = new DI\ContainerBuilder;
+
+$builder->addDefinition('foo')
+	->setType('Foo');
+$builder->addDefinition('s1')
+	->setType('Service');
+$builder->addDefinition('s2')
+	->setType('Service');
+$builder->addDefinition('s3')
+	->setType('ServiceChild');
+$builder->addDefinition('s4')
+	->setType('stdClass');
+
+$container = createContainer($builder);
+
+$foo = $container->getService('foo');
+Assert::type(Foo::class, $foo);
+Assert::same([
+	$container->getService('s1'),
+	$container->getService('s2'),
+	$container->getService('s3'),
+], $foo->bars);
+Assert::same([], $foo->foos);
+Assert::same(['default'], $foo->strings);


### PR DESCRIPTION
Autowiring of array of `Service` this way: (BC break)

```php
class Foo
{
	public $services;

	/**
	 * @param Service[] $services
	 */
	public function __construct(array $services)
	{
		$this->services = $services;
	}
}
```