### PR TITLE
Processor: replaced call of depracated getFactory() method on definition

### DIFF
--- a/src/DI/Config/Processor.php
+++ b/src/DI/Config/Processor.php
@@ -265,7 +265,7 @@ class Processor
 
 		if (array_key_exists('arguments', $config)) {
 			$arguments = $config['arguments'];
-			if (!Helpers::takeParent($arguments) && !Nette\Utils\Arrays::isList($arguments) && $definition->getFactory()) {
+			if (!Helpers::takeParent($arguments) && !Nette\Utils\Arrays::isList($arguments) && $resultDef->getFactory()) {
 				$arguments += $resultDef->getFactory()->arguments;
 			}
 			$resultDef->setArguments($arguments);


### PR DESCRIPTION
- bug fix
- BC break? no

Hi, I have found bug in beta version. When you try to use config like shown below, it throws "User Deprecated" error.

```neon
services:
	- 
		implement: SomeInterface
		arguments:
			foo: bar
```