### PR TITLE
Method for getting specific definition

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		"nette/neon": "^3.0",
 		"nette/php-generator": "^3.2",
 		"nette/robot-loader": "^3.2",
-		"nette/utils": "^3.0"
+		"nette/utils": "^3.0.1"
 	},
 	"require-dev": {
 		"nette/tester": "^2.0",

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ The recommended way to install is via Composer:
 composer require nette/di
 ```
 
-It requires PHP version 5.6 and supports PHP up to 7.2. The dev-master version requires PHP 7.1.
+It requires PHP version 7.1 and supports PHP up to 7.3.
 
 
 Usage

--- a/src/DI/CompilerExtension.php
+++ b/src/DI/CompilerExtension.php
@@ -25,7 +25,7 @@ abstract class CompilerExtension
 	/** @var string */
 	protected $name;
 
-	/** @var array */
+	/** @var array|object */
 	protected $config = [];
 
 
@@ -41,10 +41,14 @@ abstract class CompilerExtension
 
 
 	/**
+	 * @param  array|object  $config
 	 * @return static
 	 */
-	public function setConfig(array $config)
+	public function setConfig($config)
 	{
+		if (!is_array($config) && !is_object($config)) {
+			throw new Nette\InvalidArgumentException;
+		}
 		$this->config = $config;
 		return $this;
 	}
@@ -52,8 +56,9 @@ abstract class CompilerExtension
 
 	/**
 	 * Returns extension configuration.
+	 * @return array|object
 	 */
-	public function getConfig(): array
+	public function getConfig()
 	{
 		return $this->config;
 	}

--- a/src/DI/Config/Loader.php
+++ b/src/DI/Config/Loader.php
@@ -31,6 +31,8 @@ class Loader
 
 	private $loadedFiles = [];
 
+	private $parameters = [];
+
 
 	/**
 	 * Reads configuration from file.
@@ -52,7 +54,8 @@ class Loader
 		$res = [];
 		if (isset($data[self::INCLUDES_KEY])) {
 			Validators::assert($data[self::INCLUDES_KEY], 'list', "section 'includes' in file '$file'");
-			foreach ($data[self::INCLUDES_KEY] as $include) {
+			$includes = Nette\DI\Helpers::expand($data[self::INCLUDES_KEY], $this->parameters);
+			foreach ($includes as $include) {
 				$include = $this->expandIncludedFile($include, $file);
 				$res = Helpers::merge($this->load($include, $merge), $res);
 			}
@@ -118,5 +121,15 @@ class Loader
 			throw new Nette\InvalidArgumentException("Unknown file extension '$file'.");
 		}
 		return is_object($this->adapters[$extension]) ? $this->adapters[$extension] : new $this->adapters[$extension];
+	}
+
+
+	/**
+	 * @return static
+	 */
+	public function setParameters(array $params)
+	{
+		$this->parameters = $params;
+		return $this;
 	}
 }

--- a/src/DI/Config/Processor.php
+++ b/src/DI/Config/Processor.php
@@ -134,6 +134,9 @@ class Processor
 			return ['factory' => $config];
 
 		} elseif (is_array($config)) {
+			if (isset($config['class']) && !isset($config['factory'])) {
+				$config['factory'] = null;
+			}
 			foreach (['class' => 'type', 'dynamic' => 'imported'] as $alias => $original) {
 				if (array_key_exists($alias, $config)) {
 					if (array_key_exists($original, $config)) {
@@ -195,22 +198,18 @@ class Processor
 	{
 		$config = self::processArguments($config);
 
-		if (array_key_exists('type', $config) || array_key_exists('factory', $config)) {
+		if (array_key_exists('factory', $config)) {
+			$definition->setFactory($config['factory']);
 			$definition->setType(null);
-			$definition->setFactory(null);
 		}
 
 		if (array_key_exists('type', $config)) {
 			if ($config['type'] instanceof Statement) {
 				trigger_error("Service '$name': option 'type' or 'class' should be changed to 'factory'.", E_USER_DEPRECATED);
+				$definition->setFactory($config['type']);
 			} else {
 				$definition->setType($config['type']);
 			}
-			$definition->setFactory($config['type']);
-		}
-
-		if (array_key_exists('factory', $config)) {
-			$definition->setFactory($config['factory']);
 		}
 
 		if (array_key_exists('arguments', $config)) {

--- a/src/DI/ContainerBuilder.php
+++ b/src/DI/ContainerBuilder.php
@@ -137,6 +137,61 @@ class ContainerBuilder
 	}
 
 
+	public function getServiceDefinition(string $name): Nette\DI\Definitions\ServiceDefinition
+	{
+		$service = $this->getDefinition($name);
+		if ( ! $service instanceof Nette\DI\Definitions\ServiceDefinition) {
+			throw new MissingServiceException("ServiceDefinition with name '$name' not found.");
+		}
+
+		return $service;
+	}
+
+
+	public function getAccessorDefinition(string $name): Nette\DI\Definitions\AccessorDefinition
+	{
+		$service = $this->getDefinition($name);
+		if ( ! $service instanceof Nette\DI\Definitions\AccessorDefinition) {
+			throw new MissingServiceException("AccessorDefinition with name '$name' not found.");
+		}
+
+		return $service;
+	}
+
+
+	public function getFactoryDefinition(string $name): Nette\DI\Definitions\FactoryDefinition
+	{
+		$service = $this->getDefinition($name);
+		if ( ! $service instanceof Nette\DI\Definitions\FactoryDefinition) {
+			throw new MissingServiceException("FactoryDefinition with name '$name' not found.");
+		}
+
+		return $service;
+	}
+
+
+	public function getLocatorDefinition(string $name): Nette\DI\Definitions\LocatorDefinition
+	{
+		$service = $this->getDefinition($name);
+		if ( ! $service instanceof Nette\DI\Definitions\LocatorDefinition) {
+			throw new MissingServiceException("LocatorDefinition with name '$name' not found.");
+		}
+
+		return $service;
+	}
+
+
+	public function getImportedDefinition(string $name): Nette\DI\Definitions\ImportedDefinition
+	{
+		$service = $this->getDefinition($name);
+		if ( ! $service instanceof Nette\DI\Definitions\ImportedDefinition) {
+			throw new MissingServiceException("ImportedDefinition with name '$name' not found.");
+		}
+
+		return $service;
+	}
+
+
 	/**
 	 * Gets all service definitions.
 	 * @return Definition[]

--- a/src/DI/ContainerBuilder.php
+++ b/src/DI/ContainerBuilder.php
@@ -140,7 +140,7 @@ class ContainerBuilder
 	public function getServiceDefinition(string $name): Nette\DI\Definitions\ServiceDefinition
 	{
 		$service = $this->getDefinition($name);
-		if ( ! $service instanceof Nette\DI\Definitions\ServiceDefinition) {
+		if (!$service instanceof Nette\DI\Definitions\ServiceDefinition) {
 			throw new MissingServiceException("ServiceDefinition with name '$name' not found.");
 		}
 
@@ -151,7 +151,7 @@ class ContainerBuilder
 	public function getAccessorDefinition(string $name): Nette\DI\Definitions\AccessorDefinition
 	{
 		$service = $this->getDefinition($name);
-		if ( ! $service instanceof Nette\DI\Definitions\AccessorDefinition) {
+		if (!$service instanceof Nette\DI\Definitions\AccessorDefinition) {
 			throw new MissingServiceException("AccessorDefinition with name '$name' not found.");
 		}
 
@@ -162,7 +162,7 @@ class ContainerBuilder
 	public function getFactoryDefinition(string $name): Nette\DI\Definitions\FactoryDefinition
 	{
 		$service = $this->getDefinition($name);
-		if ( ! $service instanceof Nette\DI\Definitions\FactoryDefinition) {
+		if (!$service instanceof Nette\DI\Definitions\FactoryDefinition) {
 			throw new MissingServiceException("FactoryDefinition with name '$name' not found.");
 		}
 
@@ -173,7 +173,7 @@ class ContainerBuilder
 	public function getLocatorDefinition(string $name): Nette\DI\Definitions\LocatorDefinition
 	{
 		$service = $this->getDefinition($name);
-		if ( ! $service instanceof Nette\DI\Definitions\LocatorDefinition) {
+		if (!$service instanceof Nette\DI\Definitions\LocatorDefinition) {
 			throw new MissingServiceException("LocatorDefinition with name '$name' not found.");
 		}
 
@@ -184,7 +184,7 @@ class ContainerBuilder
 	public function getImportedDefinition(string $name): Nette\DI\Definitions\ImportedDefinition
 	{
 		$service = $this->getDefinition($name);
-		if ( ! $service instanceof Nette\DI\Definitions\ImportedDefinition) {
+		if (!$service instanceof Nette\DI\Definitions\ImportedDefinition) {
 			throw new MissingServiceException("ImportedDefinition with name '$name' not found.");
 		}
 

--- a/src/DI/Extensions/InjectExtension.php
+++ b/src/DI/Extensions/InjectExtension.php
@@ -102,10 +102,7 @@ final class InjectExtension extends DI\CompilerExtension
 		foreach (get_class_vars($class) as $name => $foo) {
 			$rp = new \ReflectionProperty($class, $name);
 			if (DI\Helpers::parseAnnotation($rp, 'inject') !== null) {
-				if ($type = DI\Helpers::parseAnnotation($rp, 'var')) {
-					$type = Reflection::expandClassName($type, Reflection::getPropertyDeclaringClass($rp));
-				}
-				$res[$name] = $type;
+				$res[$name] = DI\Helpers::getPropertyType($rp);
 			}
 		}
 		ksort($res);

--- a/src/DI/Helpers.php
+++ b/src/DI/Helpers.php
@@ -167,6 +167,20 @@ final class Helpers
 	}
 
 
+	public static function getPropertyType(\ReflectionProperty $prop): ?string
+	{
+		if ($type = Reflection::getPropertyType($prop)) {
+			return ($prop->getType()->allowsNull() ? '?' : '') . $type;
+		} elseif ($type = preg_replace('#\s.*#', '', (string) self::parseAnnotation($prop, 'var'))) {
+			$class = Reflection::getPropertyDeclaringClass($prop);
+			return preg_replace_callback('#[\w\\\\]+#', function ($m) use ($class) {
+				return Reflection::expandClassName($m[0], $class);
+			}, $type);
+		}
+		return null;
+	}
+
+
 	public static function normalizeClass(string $type): string
 	{
 		return class_exists($type) || interface_exists($type)

--- a/tests/DI/Compiler.extensionOverride.phpt
+++ b/tests/DI/Compiler.extensionOverride.phpt
@@ -73,6 +73,10 @@ class FooExtension extends Nette\DI\CompilerExtension
 		$builder->addDefinition('one8')
 			->setFactory('Lorem', [1])
 			->addSetup('__construct', [2]);
+		$builder->addDefinition('one9')
+			->setFactory('Lorem', [1]);
+		$builder->addDefinition('one10')
+			->setFactory('Lorem', [1]);
 
 		$builder->addDefinition('two1')
 			->setType('Lorem')
@@ -101,6 +105,12 @@ class FooExtension extends Nette\DI\CompilerExtension
 		$builder->addDefinition('two9')
 			->setType('Lorem')
 			->setFactory('Factory::createLorem', [1, 2]);
+		$builder->addDefinition('two10')
+			->setType('Lorem')
+			->setFactory('Factory::createLorem', [1]);
+		$builder->addDefinition('two11')
+			->setType('Lorem')
+			->setFactory('Factory::createLorem', [1]);
 
 		$builder->addDefinition('three1')
 			->setFactory('Factory::createLorem', [1]);
@@ -115,6 +125,10 @@ class FooExtension extends Nette\DI\CompilerExtension
 		$builder->addDefinition('three6')
 			->setFactory('Factory::createLorem', [1]);
 		$builder->addDefinition('three7')
+			->setFactory('Factory::createLorem', [1]);
+		$builder->addDefinition('three8')
+			->setFactory('Factory::createLorem', [1]);
+		$builder->addDefinition('three9')
 			->setFactory('Factory::createLorem', [1]);
 	}
 }
@@ -162,6 +176,16 @@ Assert::same([
 ], Notes::fetch());
 
 Assert::type(Ipsum::class, $container->getService('one8'));
+Assert::same([
+	'Ipsum::__construct ',
+], Notes::fetch());
+
+Assert::exception(function () use ($container) {
+	$container->getService('one9');
+}, TypeError::class, 'Return value of %a%::createServiceOne9() must be an instance of Ipsum, instance of Lorem returned');
+Notes::fetch();
+
+Assert::type(Ipsum::class, $container->getService('one10'));
 Assert::same([
 	'Ipsum::__construct ',
 ], Notes::fetch());
@@ -217,6 +241,16 @@ Assert::same([
 	'Lorem::__construct 2 new',
 ], Notes::fetch());
 
+Assert::exception(function () use ($container) {
+	$container->getService('two11');
+}, TypeError::class, 'Return value of %a%::createServiceTwo11() must be an instance of Ipsum, instance of Lorem returned');
+Notes::fetch();
+
+Assert::type(Ipsum::class, $container->getService('two12'));
+Assert::same([
+	'Ipsum::__construct ',
+], Notes::fetch());
+
 
 
 Assert::type(Ipsum::class, $container->getService('three1'));
@@ -252,4 +286,14 @@ Assert::same([
 Assert::type(Ipsum::class, $container->getService('three7'));
 Assert::same([
 	'Ipsum::__construct 2',
+], Notes::fetch());
+
+Assert::exception(function () use ($container) {
+	$container->getService('three8');
+}, TypeError::class, 'Return value of %a%::createServiceThree8() must be an instance of Ipsum, instance of Lorem returned');
+Notes::fetch();
+
+Assert::type(Ipsum::class, $container->getService('three9'));
+Assert::same([
+	'Ipsum::__construct ',
 ], Notes::fetch());

--- a/tests/DI/CompilerExtension.loadDefinitionsFromConfig.phpt
+++ b/tests/DI/CompilerExtension.loadDefinitionsFromConfig.phpt
@@ -27,6 +27,6 @@ $compilerExtension = (new CompilerExtension)->setCompiler($compiler, 'blog');
 $compilerExtension->loadDefinitionsFromConfig($config['services']);
 
 
-Assert::same('@blog.articles', $builder->getDefinition('blog.comments')->getFactory()->arguments[1]);
-Assert::equal(new Reference('blog.articles'), $builder->getDefinition('blog.articlesList')->getFactory()->arguments[0]);
-Assert::equal(new Reference('blog.comments'), $builder->getDefinition('blog.commentsControl')->getFactory()->arguments[0]->getEntity());
+Assert::same('@blog.articles', $builder->getServiceDefinition('blog.comments')->getFactory()->arguments[1]);
+Assert::equal(new Reference('blog.articles'), $builder->getServiceDefinition('blog.articlesList')->getFactory()->arguments[0]);
+Assert::equal(new Reference('blog.comments'), $builder->getServiceDefinition('blog.commentsControl')->getFactory()->arguments[0]->getEntity());

--- a/tests/DI/Config.Processor.normalizeConfig.phpt
+++ b/tests/DI/Config.Processor.normalizeConfig.phpt
@@ -43,7 +43,7 @@ Assert::same(['implement' => Iface::class, 'tagged' => 123], $processor->normali
 
 
 // aliases
-Assert::same(['type' => 'val'], $processor->normalizeConfig(['class' => 'val']));
+Assert::same(['factory' => null, 'type' => 'val'], $processor->normalizeConfig(['class' => 'val']));
 Assert::same(['imported' => 'val'], $processor->normalizeConfig(['dynamic' => 'val']));
 
 Assert::exception(function () use ($processor) {

--- a/tests/DI/ContainerBuilder.getAccessorDefinition.phpt
+++ b/tests/DI/ContainerBuilder.getAccessorDefinition.phpt
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Test: Nette\DI\ContainerBuilder::getAccessorDefinition()
+ */
+
+declare(strict_types=1);
+
+use Nette\DI;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+interface AccessorDefinition
+{
+	public function get();
+}
+
+$builder = new DI\ContainerBuilder;
+$definitionOne = $builder->addAccessorDefinition('one')
+	->setImplement(AccessorDefinition::class)
+	->setClass(\stdClass::class);
+
+$builder->addDefinition('two')
+	->setType(stdClass::class);
+
+
+$definition = $builder->getAccessorDefinition('one');
+Assert::same($definitionOne, $definition);
+
+Assert::exception(function () use ($builder) {
+	$builder->getAccessorDefinition('unknown');
+}, Nette\DI\MissingServiceException::class, "Service 'unknown' not found.");
+
+Assert::exception(function () use ($builder) {
+	$builder->getAccessorDefinition('two');
+}, Nette\DI\MissingServiceException::class, "AccessorDefinition with name 'two' not found.");

--- a/tests/DI/ContainerBuilder.getFactoryDefinition.phpt
+++ b/tests/DI/ContainerBuilder.getFactoryDefinition.phpt
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Test: Nette\DI\ContainerBuilder::getFactoryDefinition()
+ */
+
+declare(strict_types=1);
+
+use Nette\DI;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+$builder = new DI\ContainerBuilder;
+$definitionOne = $builder->addFactoryDefinition('one');
+$definitionOne->getResultDefinition()
+	->setFactory(SplFileInfo::class);
+
+$builder->addDefinition('two')
+	->setType(stdClass::class);
+
+
+$definition = $builder->getFactoryDefinition('one');
+Assert::same($definitionOne, $definition);
+
+Assert::exception(function () use ($builder) {
+	$builder->getFactoryDefinition('unknown');
+}, Nette\DI\MissingServiceException::class, "Service 'unknown' not found.");
+
+Assert::exception(function () use ($builder) {
+	$builder->getFactoryDefinition('two');
+}, Nette\DI\MissingServiceException::class, "FactoryDefinition with name 'two' not found.");

--- a/tests/DI/ContainerBuilder.getImportedDefinition.phpt
+++ b/tests/DI/ContainerBuilder.getImportedDefinition.phpt
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Test: Nette\DI\ContainerBuilder::getAccessorDefinition()
+ */
+
+declare(strict_types=1);
+
+use Nette\DI;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+$builder = new DI\ContainerBuilder;
+$definitionOne = $builder->addImportedDefinition('one');
+
+$builder->addDefinition('two')
+	->setType(stdClass::class);
+
+
+$definition = $builder->getImportedDefinition('one');
+Assert::same($definitionOne, $definition);
+
+Assert::exception(function () use ($builder) {
+	$builder->getImportedDefinition('unknown');
+}, Nette\DI\MissingServiceException::class, "Service 'unknown' not found.");
+
+Assert::exception(function () use ($builder) {
+	$builder->getImportedDefinition('two');
+}, Nette\DI\MissingServiceException::class, "ImportedDefinition with name 'two' not found.");

--- a/tests/DI/ContainerBuilder.getImportedDefinition.phpt
+++ b/tests/DI/ContainerBuilder.getImportedDefinition.phpt
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Test: Nette\DI\ContainerBuilder::getAccessorDefinition()
+ * Test: Nette\DI\ContainerBuilder::getImportedDefinition()
  */
 
 declare(strict_types=1);

--- a/tests/DI/ContainerBuilder.getLocatorDefinition.phpt
+++ b/tests/DI/ContainerBuilder.getLocatorDefinition.phpt
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Test: Nette\DI\ContainerBuilder::getAccessorDefinition()
+ * Test: Nette\DI\ContainerBuilder::getLocatorDefinition()
  */
 
 declare(strict_types=1);

--- a/tests/DI/ContainerBuilder.getLocatorDefinition.phpt
+++ b/tests/DI/ContainerBuilder.getLocatorDefinition.phpt
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Test: Nette\DI\ContainerBuilder::getAccessorDefinition()
+ */
+
+declare(strict_types=1);
+
+use Nette\DI;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+$builder = new DI\ContainerBuilder;
+$definitionOne = $builder->addLocatorDefinition('one');
+
+$builder->addDefinition('two')
+	->setType(stdClass::class);
+
+
+$definition = $builder->getLocatorDefinition('one');
+Assert::same($definitionOne, $definition);
+
+Assert::exception(function () use ($builder) {
+	$builder->getLocatorDefinition('unknown');
+}, Nette\DI\MissingServiceException::class, "Service 'unknown' not found.");
+
+Assert::exception(function () use ($builder) {
+	$builder->getLocatorDefinition('two');
+}, Nette\DI\MissingServiceException::class, "LocatorDefinition with name 'two' not found.");

--- a/tests/DI/ContainerBuilder.getServiceDefinition.phpt
+++ b/tests/DI/ContainerBuilder.getServiceDefinition.phpt
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Test: Nette\DI\ContainerBuilder::getServiceDefinition()
+ */
+
+declare(strict_types=1);
+
+use Nette\DI;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+$builder = new DI\ContainerBuilder;
+$definitionOne = $builder->addDefinition('one')
+	->setType(stdClass::class);
+
+$builder->addFactoryDefinition('two')
+	->getResultDefinition()
+	->setFactory(SplFileInfo::class);
+
+
+$definition = $builder->getServiceDefinition('one');
+Assert::same($definitionOne, $definition);
+
+Assert::exception(function () use ($builder) {
+	$builder->getServiceDefinition('unknown');
+}, Nette\DI\MissingServiceException::class, "Service 'unknown' not found.");
+
+Assert::exception(function () use ($builder) {
+	$builder->getServiceDefinition('two');
+}, Nette\DI\MissingServiceException::class, "ServiceDefinition with name 'two' not found.");

--- a/tests/DI/DecoratorExtension.basic.phpt
+++ b/tests/DI/DecoratorExtension.basic.phpt
@@ -79,4 +79,4 @@ Assert::equal([
 	new Statement([new Reference('self'), 'setup'], ['Iface']),
 	new Statement([new Reference('self'), 'setup']),
 	new Statement([new Reference('self'), '$a'], [10]),
-], $builder->getDefinition('one')->getSetup());
+], $builder->getServiceDefinition('one')->getSetup());

--- a/tests/DI/Helpers.getPropertyType.php74.phptx
+++ b/tests/DI/Helpers.getPropertyType.php74.phptx
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Test: Nette\DI\Helpers::getPropertyType
+ * @phpversion 7.4
+ */
+
+declare(strict_types=1);
+
+namespace NS
+{
+	use Test\B;
+
+	class A
+	{
+		public $noType;
+		public B $classType;
+		public string $nativeType;
+		public self $selfType;
+		public ?B $nullableClassType;
+		public ?string $nullableNativeType;
+		public ?self $nullableSelfType;
+
+		/** @var B noise */
+		public $annotationClassType;
+
+		/** @var B|null|string */
+		public $annotationUnionType;
+
+		/** @var String */
+		public $annotationNativeType;
+
+		/** @var self */
+		public $annotationSelfType;
+
+		/** @var static */
+		public $annotationStaticType;
+
+		/** @var ?B */
+		public $annotationNullable;
+	}
+}
+
+namespace
+{
+	use Nette\DI\Helpers;
+	use Tester\Assert;
+
+	require __DIR__ . '/../bootstrap.php';
+
+
+	Assert::null(Helpers::getPropertyType(new \ReflectionProperty(NS\A::class, 'noType')));
+
+	Assert::same('Test\B', Helpers::getPropertyType(new \ReflectionProperty(NS\A::class, 'classType')));
+
+	Assert::same('string', Helpers::getPropertyType(new \ReflectionProperty(NS\A::class, 'nativeType')));
+
+	Assert::same('NS\A', Helpers::getPropertyType(new \ReflectionProperty(NS\A::class, 'selfType')));
+
+	Assert::same('?Test\B', Helpers::getPropertyType(new \ReflectionProperty(NS\A::class, 'nullableClassType')));
+
+	Assert::same('?string', Helpers::getPropertyType(new \ReflectionProperty(NS\A::class, 'nullableNativeType')));
+
+	Assert::same('?NS\A', Helpers::getPropertyType(new \ReflectionProperty(NS\A::class, 'nullableSelfType')));
+
+	Assert::same('Test\B', Helpers::getPropertyType(new \ReflectionProperty(NS\A::class, 'annotationClassType')));
+
+	Assert::same('Test\B|null|string', Helpers::getPropertyType(new \ReflectionProperty(NS\A::class, 'annotationUnionType')));
+
+	Assert::same('string', Helpers::getPropertyType(new \ReflectionProperty(NS\A::class, 'annotationNativeType')));
+
+	Assert::same('NS\A', Helpers::getPropertyType(new \ReflectionProperty(NS\A::class, 'annotationSelfType')));
+
+	Assert::same('?Test\B', Helpers::getPropertyType(new \ReflectionProperty(NS\A::class, 'annotationNullable')));
+}

--- a/tests/DI/Helpers.getPropertyType.phpt
+++ b/tests/DI/Helpers.getPropertyType.phpt
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Test: Nette\DI\Helpers::getPropertyType
+ */
+
+declare(strict_types=1);
+
+namespace NS
+{
+	use Test\B;
+
+	class A
+	{
+		public $noType;
+
+		/** @var B noise */
+		public $annotationClassType;
+
+		/** @var B|null|string */
+		public $annotationUnionType;
+
+		/** @var String */
+		public $annotationNativeType;
+
+		/** @var self */
+		public $annotationSelfType;
+
+		/** @var static */
+		public $annotationStaticType;
+
+		/** @var ?B */
+		public $annotationNullable;
+	}
+}
+
+namespace
+{
+	use Nette\DI\Helpers;
+	use Tester\Assert;
+
+	require __DIR__ . '/../bootstrap.php';
+
+
+	Assert::null(Helpers::getPropertyType(new \ReflectionProperty(NS\A::class, 'noType')));
+
+	Assert::same('Test\B', Helpers::getPropertyType(new \ReflectionProperty(NS\A::class, 'annotationClassType')));
+
+	Assert::same('Test\B|null|string', Helpers::getPropertyType(new \ReflectionProperty(NS\A::class, 'annotationUnionType')));
+
+	Assert::same('string', Helpers::getPropertyType(new \ReflectionProperty(NS\A::class, 'annotationNativeType')));
+
+	Assert::same('NS\A', Helpers::getPropertyType(new \ReflectionProperty(NS\A::class, 'annotationSelfType')));
+
+	Assert::same('?Test\B', Helpers::getPropertyType(new \ReflectionProperty(NS\A::class, 'annotationNullable')));
+}

--- a/tests/DI/InjectExtension.basic.phpt
+++ b/tests/DI/InjectExtension.basic.phpt
@@ -119,7 +119,7 @@ Assert::equal([
 	new Statement([new Reference('self'), '$e'], [new Reference('a')]),
 	new Statement([new Reference('self'), '$c'], [new Reference('std')]),
 	new Statement([new Reference('self'), '$a'], [new Reference('std')]),
-], $builder->getDefinition('last.one')->getSetup());
+], $builder->getServiceDefinition('last.one')->getSetup());
 
 Assert::equal([
 	new Statement([new Reference('self'), 'injectA']),
@@ -129,7 +129,7 @@ Assert::equal([
 	new Statement([new Reference('self'), '$e'], [new Reference('a')]),
 	new Statement([new Reference('self'), '$c'], [new Reference('std')]),
 	new Statement([new Reference('self'), '$a'], [new Reference('std')]),
-], $builder->getDefinition('ext.one')->getSetup());
+], $builder->getServiceDefinition('ext.one')->getSetup());
 
 Assert::equal([
 	new Statement([new Reference('self'), 'injectA']),
@@ -139,4 +139,4 @@ Assert::equal([
 	new Statement([new Reference('self'), '$e'], [new Reference('b')]),
 	new Statement([new Reference('self'), '$c'], [new Reference('std')]),
 	new Statement([new Reference('self'), '$a'], [new Reference('std')]),
-], $builder->getDefinition('two')->getSetup());
+], $builder->getServiceDefinition('two')->getSetup());

--- a/tests/DI/InjectExtension.implement.phpt
+++ b/tests/DI/InjectExtension.implement.phpt
@@ -47,4 +47,4 @@ $builder = $compiler->getContainerBuilder();
 
 Assert::equal([
 	new Statement([new Reference('self'), 'injectFoo'], [new Reference('01')]),
-], $builder->getDefinition('sf')->getResultDefinition()->getSetup());
+], $builder->getFactoryDefinition('sf')->getResultDefinition()->getSetup());

--- a/tests/DI/Loader.include.params.phpt
+++ b/tests/DI/Loader.include.params.phpt
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Test: Nette\DI\Config\Loader: including files
+ */
+
+declare(strict_types=1);
+
+use Nette\DI\Config;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+Assert::exception(function () {
+	$config = new Config\Loader;
+	$data = $config->load('files/loader.includes.params.neon');
+}, Nette\InvalidArgumentException::class, "Missing parameter 'name'.");
+
+
+test(function () {
+	$config = new Config\Loader;
+	$config->setParameters(['name' => 'loader.includes.params.child']);
+	$data = $config->load('files/loader.includes.params.neon');
+
+	Assert::same([
+		'files/loader.includes.params.neon',
+		'files/loader.includes.params.child.neon',
+	], $config->getDependencies());
+
+	Assert::same([
+		'parameters' => [
+			'foo' => 'bar',
+			'name' => 'ignored',
+		],
+	], $data);
+});

--- a/tests/DI/files/compiler.extensionOverride.neon
+++ b/tests/DI/files/compiler.extensionOverride.neon
@@ -18,6 +18,10 @@ services:
 		factory: IpsumFactory::create(2)
 	one8!:
 		factory: Ipsum
+	one9:
+		type: Ipsum
+	one10:
+		class: Ipsum
 
 	two1:
 		factory: Ipsum
@@ -42,6 +46,10 @@ services:
 	two10:
 		factory: Factory::createLorem(2)
 		arguments: [1: new]
+	two11:
+		type: Ipsum
+	two12:
+		class: Ipsum
 
 	three1:
 		factory: Ipsum
@@ -59,3 +67,7 @@ services:
 		arguments: [2]
 	three7:
 		factory: IpsumFactory::create(2)
+	three8:
+		type: Ipsum
+	three9:
+		class: Ipsum

--- a/tests/DI/files/loader.includes.params.child.neon
+++ b/tests/DI/files/loader.includes.params.child.neon
@@ -1,0 +1,2 @@
+parameters:
+	foo: bar

--- a/tests/DI/files/loader.includes.params.neon
+++ b/tests/DI/files/loader.includes.params.neon
@@ -1,0 +1,5 @@
+parameters:
+	name: ignored
+
+includes:
+	- %name%.neon


### PR DESCRIPTION
- new feature 
- BC break? no
- doc PR:

There are specific add*Definition methods for each type of Definition but no get*Definition for getting specific definitions. You can only use `\Nette\DI\ContainerBuilder::getDefinition` with abstract return type `\Nette\DI\Definitions\Definition` so in your extensions you have to every time assert that you are getting right type of Definition so you can use Definition specific methods.

So I added specific Getters like `\Nette\DI\ContainerBuilder::getServiceDefinition`.