### PR TITLE
Added Decorator extension to $last

### DIFF
--- a/src/DI/Compiler.php
+++ b/src/DI/Compiler.php
@@ -216,7 +216,7 @@ class Compiler
 			$extension->loadConfiguration();
 		}
 
-		$last = $this->getExtensions(Extensions\InjectExtension::class) + $this->getExtensions(Extensions\DecoratorExtension::class);
+		$last = $this->getExtensions(Extensions\DecoratorExtension::class) + $this->getExtensions(Extensions\InjectExtension::class);
 		$this->extensions = array_merge(array_diff_key($this->extensions, $last), $last);
 
 		$extensions = array_diff_key($this->extensions, $first, [self::SERVICES => 1]);

--- a/src/DI/Compiler.php
+++ b/src/DI/Compiler.php
@@ -216,7 +216,7 @@ class Compiler
 			$extension->loadConfiguration();
 		}
 
-		$last = $this->getExtensions(Extensions\InjectExtension::class);
+		$last = $this->getExtensions(Extensions\InjectExtension::class) + $this->getExtensions(Extensions\DecoratorExtension::class);
 		$this->extensions = array_merge(array_diff_key($this->extensions, $last), $last);
 
 		$extensions = array_diff_key($this->extensions, $first, [self::SERVICES => 1]);


### PR DESCRIPTION
- Bug fix
- BC break? no

Decorator extension needs to be resolved last (eg. after Search extension) in order to find all possible matching services.

Solves my issue where decorator doesn't decorate services found using Search extension.