### PR TITLE
SearchExtension - ability to create factory definitions from interfaces

### DIFF
--- a/src/DI/Extensions/SearchExtension.php
+++ b/src/DI/Extensions/SearchExtension.php
@@ -114,8 +114,7 @@ final class SearchExtension extends Nette\DI\CompilerExtension
 
 			if ($rc->isInstantiable()) {
 				$instantiable[] = $rc->getName();
-			}
-			elseif ($rc->isInterface()) {
+			} elseif ($rc->isInterface()) {
 				$interface[] = $rc->getName();
 			}
 		}


### PR DESCRIPTION
- new feature  #196 
- BC break? no

This PR extends SearchExtension to be able to search for interfaces and create factory definitions from them.

WIP is added due to some duplicate code that needs to be refactored.