### PR TITLE
Generate cached container file independently of class existence

### DIFF
--- a/src/DI/ContainerLoader.php
+++ b/src/DI/ContainerLoader.php
@@ -40,9 +40,7 @@ class ContainerLoader
 	public function load(callable $generator, $key = null): string
 	{
 		$class = $this->getClassName($key);
-		if (!class_exists($class, false)) {
-			$this->loadFile($class, $generator);
-		}
+		$this->loadFile($class, $generator);
 		return $class;
 	}
 


### PR DESCRIPTION
- bug fix
- BC break? no
- doc PR: not needed

I have a build reload command which deletes cache and then generate all possible container configurations (console, debug, production, ...). During cache removal is deleted also currently running container so class exists while it's file not and I need to create it again