### PR TITLE
Remove redundant $service variable in case of simply service without dependencies.

### DIFF
--- a/src/DI/PhpGenerator.php
+++ b/src/DI/PhpGenerator.php
@@ -90,6 +90,9 @@ declare(strict_types=1);
 			$method->setVisibility('public');
 			$method->setReturnType($def->getType());
 			$def->generateMethod($method, $this);
+			if (preg_match('/^\$service\s=\s((?:new\s[^\;]+|[^;:]+::\w+\(\))\;)\n\s*return\s\$service\;$/', $method->getBody(), $methodBodyParser)) {
+				$method->setBody('return '.$methodBodyParser[1]);
+			}
 			return $method;
 
 		} catch (\Exception $e) {

--- a/src/DI/PhpGenerator.php
+++ b/src/DI/PhpGenerator.php
@@ -91,7 +91,7 @@ declare(strict_types=1);
 			$method->setReturnType($def->getType());
 			$def->generateMethod($method, $this);
 			if (preg_match('/^\$service\s=\s((?:new\s[^\;]+|[^;:]+::\w+\(\))\;)\n\s*return\s\$service\;$/', $method->getBody(), $methodBodyParser)) {
-				$method->setBody('return '.$methodBodyParser[1]);
+				$method->setBody('return ' . $methodBodyParser[1]);
 			}
 			return $method;
 


### PR DESCRIPTION
In case of:

```php
public function createServiceMyService(): Model\MyService
{
	$service = new Model\MyService;
	return $service;
}
```

Generate simplify version:

```php
public function createServiceMyService(): Model\MyService
{
	return new Model\MyService;
}
```

And in case of simple static service:

```php
public function createServiceMyService(): Model\MyService
{
	$service = Model\MyServiceFactory::getInstance();
	return $service;
}
```

Generate:

```
public function createServiceMyService(): Model\MyService
{
	return Model\MyServiceFactory::getInstance();
}
```