### PR TITLE
PHPDoc tag @return with type mixed is not subtype of native type bool

### DIFF
--- a/src/DI/Config/Helpers.php
+++ b/src/DI/Config/Helpers.php
@@ -35,7 +35,7 @@ final class Helpers
 
 	/**
 	 * Return true if array prevents merging and removes this information.
-	 * @return mixed
+	 * @return bool
 	 */
 	public static function takeParent(&$data): bool
 	{


### PR DESCRIPTION
- bug fix
- BC break? no

Fix error:

```
------ ------------------------------------------------------------------------ 
  Line   DI/Config/Helpers.php                                                   
 ------ ------------------------------------------------------------------------ 
  40     PHPDoc tag @return with type mixed is not subtype of native type bool.  
 ------ ------------------------------------------------------------------------ 
```