### PR TITLE
Name can accept null.

### DIFF
--- a/src/DI/Definitions/Definition.php
+++ b/src/DI/Definitions/Definition.php
@@ -19,7 +19,7 @@ abstract class Definition
 {
 	use Nette\SmartObject;
 
-	/** @var string */
+	/** @var string|null */
 	private $name;
 
 	/** @var string|null  class or interface name */


### PR DESCRIPTION
- bug fix
- BC break? no

Fix error:

```
 ------ ------------------------------------------------------------------- 
  Line   DI/Definitions/Definition.php                                      
 ------ ------------------------------------------------------------------- 
  159    Property Nette\DI\Definitions\Definition::$name (string) does not  
         accept null.                                                       
 ------ ------------------------------------------------------------------- 
```