### PR TITLE
ExtensionsExtension: Fix type hint of RC

### DIFF
--- a/src/DI/Extensions/ExtensionsExtension.php
+++ b/src/DI/Extensions/ExtensionsExtension.php
@@ -30,8 +30,9 @@ final class ExtensionsExtension extends Nette\DI\CompilerExtension
 				$name = null;
 			}
 			if ($class instanceof Nette\DI\Definitions\Statement) {
-				$rc = new \ReflectionClass($class->getEntity());
-				$this->compiler->addExtension($name, $rc->newInstanceArgs($class->arguments));
+				/** @var Nette\DI\CompilerExtension $rcExtension */
+				$rcExtension = (new \ReflectionClass($class->getEntity()))->newInstanceArgs($class->arguments);
+				$this->compiler->addExtension($name, $rcExtension);
 			} else {
 				$this->compiler->addExtension($name, new $class);
 			}

--- a/src/DI/Extensions/ExtensionsExtension.php
+++ b/src/DI/Extensions/ExtensionsExtension.php
@@ -30,9 +30,15 @@ final class ExtensionsExtension extends Nette\DI\CompilerExtension
 				$name = null;
 			}
 			if ($class instanceof Nette\DI\Definitions\Statement) {
-				/** @var Nette\DI\CompilerExtension $rcExtension */
 				$rcExtension = (new \ReflectionClass($class->getEntity()))->newInstanceArgs($class->arguments);
-				$this->compiler->addExtension($name, $rcExtension);
+				if ($rcExtension instanceof Nette\DI\CompilerExtension) {
+					$this->compiler->addExtension($name, $rcExtension);
+				} else {
+					throw new Nette\DI\InvalidConfigurationException(
+						"Statement extension expected type '" . Nette\DI\CompilerExtension::class . "', "
+						. "but type of '" . \get_class($rcExtension) . "' given."
+					);
+				}
 			} else {
 				$this->compiler->addExtension($name, new $class);
 			}


### PR DESCRIPTION
- bug fix
- BC break? no

Fix type hint and solve error:

```
------ --------------------------------------------------------------------- 
  Line   DI/Extensions/ExtensionsExtension.php                                
 ------ --------------------------------------------------------------------- 
  34     Parameter #2 $extension of method Nette\DI\Compiler::addExtension()  
         expects Nette\DI\CompilerExtension, object given.                    
 ------ --------------------------------------------------------------------- 
```