### PR TITLE
InjectExtension: Fix type hint and always executed if.

### DIFF
--- a/src/DI/Extensions/InjectExtension.php
+++ b/src/DI/Extensions/InjectExtension.php
@@ -32,12 +32,11 @@ final class InjectExtension extends DI\CompilerExtension
 	public function beforeCompile()
 	{
 		foreach ($this->getContainerBuilder()->getDefinitions() as $def) {
-			if (
-				$def->getTag(self::TAG_INJECT)
-				&& ($def = $def instanceof Definitions\FactoryDefinition ? $def->getResultDefinition() : $def)
-				&& ($def instanceof Definitions\ServiceDefinition)
-			) {
-				$this->updateDefinition($def);
+			if ($def->getTag(self::TAG_INJECT)) {
+				$def = $def instanceof Definitions\FactoryDefinition ? $def->getResultDefinition() : $def;
+				if ($def instanceof Definitions\ServiceDefinition) {
+					$this->updateDefinition($def);
+				}
 			}
 		}
 	}
@@ -142,7 +141,7 @@ final class InjectExtension extends DI\CompilerExtension
 
 	/**
 	 * @param  object|string  $class
-	 * @param  DI\Resolver|DI\Container  $container
+	 * @param  DI\Resolver|DI\Container|DI\ContainerBuilder|null  $container
 	 */
 	private static function checkType($class, string $name, ?string $type, $container = null): void
 	{


### PR DESCRIPTION
- bug fix
- BC break? no

Fix type error and if condition order:

```
 ------ ---------------------------------------------------------- 
  Line   DI/Extensions/InjectExtension.php                         
 ------ ---------------------------------------------------------- 
  37     Right side of && is always true.                          
  61     Parameter #4 $container of static method                  
         Nette\DI\Extensions\InjectExtension::checkType() expects  
         Nette\DI\Container|Nette\DI\Resolver|null,                
         Nette\DI\ContainerBuilder|null given.                     
 ------ ---------------------------------------------------------- 
```