### PR TITLE
Helpers: Annotation for hinting ->getDocComment().

### DIFF
--- a/src/DI/Helpers.php
+++ b/src/DI/Helpers.php
@@ -147,6 +147,7 @@ final class Helpers
 
 	/**
 	 * Returns an annotation value.
+	 * @param \Reflector|\ReflectionMethod $ref
 	 */
 	public static function parseAnnotation(\Reflector $ref, string $name): ?string
 	{


### PR DESCRIPTION
- bug fix
- BC break? yes

Solve error:

```
 ------ --------------------------------------------------------- 
  Line   DI/Helpers.php                                           
 ------ --------------------------------------------------------- 
  157    Call to an undefined method Reflector::getDocComment().  
  157    Call to an undefined method Reflector::getDocComment().  
 ------ --------------------------------------------------------- 
```