### PR TITLE
PhpGenerator: $name might not be defined

### DIFF
--- a/src/Bridges/DITracy/ContainerPanel.php
+++ b/src/Bridges/DITracy/ContainerPanel.php
@@ -27,7 +27,7 @@ class ContainerPanel implements Tracy\IBarPanel
 	/** @var Nette\DI\Container */
 	private $container;
 
-	/** @var int|null */
+	/** @var int|float|null */
 	private $elapsedTime;
 
 

--- a/src/DI/PhpGenerator.php
+++ b/src/DI/PhpGenerator.php
@@ -84,8 +84,8 @@ declare(strict_types=1);
 
 	public function generateMethod(Definitions\Definition $def): Nette\PhpGenerator\Method
 	{
+		$name = $def->getName();
 		try {
-			$name = $def->getName();
 			$method = new Nette\PhpGenerator\Method(Container::getMethodName($name));
 			$method->setVisibility('public');
 			$method->setReturnType($def->getType());


### PR DESCRIPTION
- bug fix
- BC break? no

Solve:

```
 ------ -------------------------------------- 
  Line   DI/PhpGenerator.php                   
 ------ -------------------------------------- 
  99     Variable $name might not be defined.  
 ------ -------------------------------------- 
```