### PR TITLE
Resolver: Fix undefined and never called spaces.

### DIFF
--- a/src/DI/Resolver.php
+++ b/src/DI/Resolver.php
@@ -108,12 +108,12 @@ class Resolver
 				}
 			}
 
-			/** @var \ReflectionMethod $reflection */
-			$reflection = Nette\Utils\Callback::toReflection($entity[0] === '' ? $entity[1] : $entity);
-
 			try {
+				/** @var \ReflectionMethod $reflection */
+				$reflection = Nette\Utils\Callback::toReflection($entity[0] === '' ? $entity[1] : $entity);
 				$refClass = $reflection instanceof \ReflectionMethod ? $reflection->getDeclaringClass() : null;
 			} catch (\ReflectionException $e) {
+				$reflection = null;
 				$refClass = null;
 			}
 


### PR DESCRIPTION
- bug fix
- BC break? no

Fix and basic reimplementation for define type hints in comment section and little code reorganization.

```
 ------ --------------------------------------------------------------------- 
  Line   DI/Resolver.php                                                      
 ------ --------------------------------------------------------------------- 
  117    Call to an undefined method ReflectionFunctionAbstract::isPublic().  
  117    Variable $refClass might not be defined.                             
  117    Variable $reflection might not be defined.                           
  118    Call to an undefined method ReflectionFunctionAbstract::isStatic().  
  118    Variable $reflection might not be defined.                           
  122    Variable $reflection might not be defined.                           
  124    Variable $reflection might not be defined.                           
  335    Negated boolean expression is always false.                          
 ------ --------------------------------------------------------------------- 
```