### PR TITLE
Resolver: better exception message

### DIFF
--- a/src/DI/Resolver.php
+++ b/src/DI/Resolver.php
@@ -134,10 +134,10 @@ class Resolver
 
 		} elseif (is_string($entity)) { // class
 			if (!class_exists($entity)) {
-				throw new ServiceCreationException(
-					'Class ' . $entity . ' not found.'
-					. (interface_exists($entity) ? ' Interface ' . $entity . ' can not be used in factory section as service.' : '')
-				);
+				if (interface_exists($entity)) {
+					throw new ServiceCreationException('Interface \'' . $entity . '\' can not be used as \'factory\', did you mean \'implement\'?');
+				}
+				throw new ServiceCreationException("Class $entity not found.");
 			}
 			return $entity;
 		}

--- a/src/DI/Resolver.php
+++ b/src/DI/Resolver.php
@@ -134,7 +134,10 @@ class Resolver
 
 		} elseif (is_string($entity)) { // class
 			if (!class_exists($entity)) {
-				throw new ServiceCreationException("Class $entity not found.");
+				throw new ServiceCreationException(
+					'Class \'' . $entity . '\' not found.'
+					. (interface_exists($entity) ? ' Interface \'' . $entity . '\' can not be used in \'factory\' section as service.' : '')
+				);
 			}
 			return $entity;
 		}

--- a/src/DI/Resolver.php
+++ b/src/DI/Resolver.php
@@ -135,8 +135,8 @@ class Resolver
 		} elseif (is_string($entity)) { // class
 			if (!class_exists($entity)) {
 				throw new ServiceCreationException(
-					'Class \'' . $entity . '\' not found.'
-					. (interface_exists($entity) ? ' Interface \'' . $entity . '\' can not be used in \'factory\' section as service.' : '')
+					'Class ' . $entity . ' not found.'
+					. (interface_exists($entity) ? ' Interface ' . $entity . ' can not be used in factory section as service.' : '')
 				);
 			}
 			return $entity;


### PR DESCRIPTION
- bug fix
- BC break? no

In case of neon file:

```yaml
services:
   tagManagerAccessor:
      factory: Namespace\TagManagerAccessor
```

Nette throws user unfriendly exception:

`Class 'Namespace\TagManagerAccessor' not found.`

I think if the class does not exist, but the interface does, Nette should throw more user-friendly exception like:

`Service 'tagManagerAccessor': Class 'Namespace\TagManagerAccessor' not found. Interface 'Namespace\TagManagerAccessor' can not be used in 'factory' section as service.`

Thanks.