### PR TITLE
Allow disabling strict types.

### DIFF
--- a/src/DI/Compiler.php
+++ b/src/DI/Compiler.php
@@ -46,6 +46,9 @@ class Compiler
 	/** @var string */
 	private $className = 'Container';
 
+	/** @var bool */
+	private $strictTypes = true;
+
 
 	public function __construct(ContainerBuilder $builder = null)
 	{
@@ -96,6 +99,17 @@ class Compiler
 	public function setClassName(string $className)
 	{
 		$this->className = $className;
+		return $this;
+	}
+
+
+	/**
+	 * Enables/disables declare(strict_types=1) in generated code.
+	 * @return static
+	 */
+	public function setStrictTypes(bool $on)
+	{
+		$this->strictTypes = $on;
 		return $this;
 	}
 
@@ -281,7 +295,7 @@ class Compiler
 
 		$this->builder->complete();
 
-		$generator = new PhpGenerator($this->builder);
+		$generator = new PhpGenerator($this->builder, $this->strictTypes);
 		$class = $generator->generate($this->className);
 		$this->dependencies->add($this->builder->getDependencies());
 

--- a/src/DI/PhpGenerator.php
+++ b/src/DI/PhpGenerator.php
@@ -29,10 +29,25 @@ class PhpGenerator
 	/** @var string */
 	private $className;
 
+	/** @var bool */
+	private $strictTypes = true;
 
-	public function __construct(ContainerBuilder $builder)
+
+	public function __construct(ContainerBuilder $builder, bool $strictTypes = true)
 	{
 		$this->builder = $builder;
+		$this->strictTypes = $strictTypes;
+	}
+
+
+	/**
+	 * Enables/disables declare(strict_types=1) in generated code.
+	 * @return static
+	 */
+	public function setStrictTypes(bool $on)
+	{
+		$this->strictTypes = $on;
+		return $this;
 	}
 
 
@@ -76,7 +91,7 @@ class PhpGenerator
 	{
 		return '/** @noinspection PhpParamsInspection,PhpMethodMayBeStaticInspection */
 
-declare(strict_types=1);
+' . ($this->strictTypes ? 'declare(strict_types=1);' : '') . '
 
 ' . $class->__toString();
 	}


### PR DESCRIPTION
- new feature (or maybe a bug fix?)
- BC break? **no**

Raw usage:
```php
$c = new Compiler();
$c->setStrictTypes(false);
$code = $c->compile(); // Et voila! No strict types.
```

With nette/bootstrap in a Nette application:
```php
$configurator = new Configurator();
$configurator->onCompile() = function(Compiler $c){
    $c->setStrictTypes(false);
};
$configurator->createContainer();
// Et voila! No strict types.
```