### PR TITLE
Container phpstan generics

### DIFF
--- a/src/DI/Container.php
+++ b/src/DI/Container.php
@@ -265,6 +265,9 @@ class Container
 	 * Creates new instance using autowiring.
 	 * @return object
 	 * @throws Nette\InvalidArgumentException
+	 * @template T of object
+	 * @phpstan-param class-string<T> $class
+	 * @phpstan-return T
 	 */
 	public function createInstance(string $class, array $args = [])
 	{

--- a/src/DI/Container.php
+++ b/src/DI/Container.php
@@ -205,6 +205,9 @@ class Container
 	 * @param  bool  $throw  exception if service doesn't exist?
 	 * @return object|null  service
 	 * @throws MissingServiceException
+	 * @template T of object
+	 * @phpstan-param class-string<T> $type
+	 * @phpstan-return T|null
 	 */
 	public function getByType(string $type, bool $throw = true)
 	{


### PR DESCRIPTION
- new feature
- BC break? no
- doc PR: not needed

It helps phpstan understand that returned instance is always instance of $class