### PR TITLE
SearchExtension: Exception when class is not autoloaded.

### DIFF
--- a/src/DI/Extensions/SearchExtension.php
+++ b/src/DI/Extensions/SearchExtension.php
@@ -89,6 +89,9 @@ final class SearchExtension extends Nette\DI\CompilerExtension
 
 		$found = [];
 		foreach ($classes as $class) {
+			if (\class_exists($class) === false) {
+				throw new Nette\InvalidStateException('Class "' . $class . '" does not exist. Did you use an autoloader?');
+			}
 			$rc = new \ReflectionClass($class);
 			if (
 				($rc->isInstantiable()

--- a/src/DI/Extensions/SearchExtension.php
+++ b/src/DI/Extensions/SearchExtension.php
@@ -89,10 +89,11 @@ final class SearchExtension extends Nette\DI\CompilerExtension
 
 		$found = [];
 		foreach ($classes as $class) {
-			if (\class_exists($class) === false) {
-				throw new Nette\InvalidStateException('Class "' . $class . '" does not exist. Did you use an autoloader?');
+			try {
+				$rc = new \ReflectionClass($class);
+			} catch (\ReflectionException $e) {
+				throw new Nette\InvalidStateException($e->getMessage() . '. Did you use an autoloader?');
 			}
-			$rc = new \ReflectionClass($class);
 			if (
 				($rc->isInstantiable()
 					||


### PR DESCRIPTION
- bug fix
- BC break? no

Throw exception when class is not autoloaded.

For example I set find directory to project root, but Robot loaded is mapping `app` dir only.
