### PR TITLE
Added support for alternative annotation syntax

### DIFF
--- a/src/DI/Extensions/ParametersExtension.php
+++ b/src/DI/Extensions/ParametersExtension.php
@@ -51,7 +51,8 @@ final class ParametersExtension extends Nette\DI\CompilerExtension
 
 		// expand all except 'services'
 		$slice = array_diff_key($this->compilerConfig, ['services' => 1]);
-		$this->compilerConfig = Nette\DI\Helpers::expand($slice, $builder->parameters) + $this->compilerConfig;
+		$slice = Nette\DI\Helpers::expand($slice, $builder->parameters);
+		$this->compilerConfig = $slice + $this->compilerConfig;
 	}
 
 

--- a/src/DI/Extensions/ParametersExtension.php
+++ b/src/DI/Extensions/ParametersExtension.php
@@ -52,6 +52,7 @@ final class ParametersExtension extends Nette\DI\CompilerExtension
 		// expand all except 'services'
 		$slice = array_diff_key($this->compilerConfig, ['services' => 1]);
 		$slice = Nette\DI\Helpers::expand($slice, $builder->parameters);
+		$slice = Nette\DI\Helpers::performFunctions($slice);
 		$this->compilerConfig = $slice + $this->compilerConfig;
 	}
 

--- a/src/DI/Helpers.php
+++ b/src/DI/Helpers.php
@@ -192,4 +192,27 @@ final class Helpers
 			? (new \ReflectionClass($type))->name
 			: $type;
 	}
+
+
+	/**
+	 * Non data-loss type conversion.
+	 * @param  mixed
+	 * @return mixed
+	 * @throws Nette\InvalidStateException
+	 */
+	public static function convertType($val, string $type)
+	{
+		if (is_scalar($val)) {
+			$norm = ($val === false ? '0' : (string) $val);
+			if ($type === 'float') {
+				$norm = preg_replace('#\.0*$#D', '', $norm);
+			}
+			$orig = $norm;
+			settype($norm, $type);
+			if ($orig === ($norm === false ? '0' : (string) $norm)) {
+				return $norm;
+			}
+		}
+		throw new Nette\InvalidStateException('Cannot convert ' . (is_scalar($val) ? "'$val'" : gettype($val)) . " to $type.");
+	}
 }

--- a/src/DI/Helpers.php
+++ b/src/DI/Helpers.php
@@ -113,8 +113,8 @@ final class Helpers
 			} elseif (is_array($v)) {
 				$args[$k] = self::filterArguments($v);
 			} elseif ($v instanceof Statement) {
-				$tmp = self::filterArguments([$v->getEntity()]);
-				$args[$k] = new Statement($tmp[0], self::filterArguments($v->arguments));
+				[$tmp] = self::filterArguments([$v->getEntity()]);
+				$args[$k] = new Statement($tmp, self::filterArguments($v->arguments));
 			}
 		}
 		return $args;

--- a/src/DI/Resolver.php
+++ b/src/DI/Resolver.php
@@ -181,7 +181,21 @@ class Resolver
 				break;
 
 			case $entity === 'not':
+				if (count($arguments) > 1) {
+					throw new ServiceCreationException("Function $entity() expects at most 1 parameter, " . count($arguments) . ' given.');
+				}
 				$entity = ['', '!'];
+				break;
+
+			case $entity === 'bool':
+			case $entity === 'int':
+			case $entity === 'float':
+			case $entity === 'string':
+				if (count($arguments) > 1) {
+					throw new ServiceCreationException("Function $entity() expects at most 1 parameter, " . count($arguments) . ' given.');
+				}
+				$arguments = [$arguments[0], $entity];
+				$entity = [Helpers::class, 'convertType'];
 				break;
 
 			case is_string($entity): // create class

--- a/src/DI/Resolver.php
+++ b/src/DI/Resolver.php
@@ -554,6 +554,15 @@ class Resolver
 			&& (class_exists($itemType) || interface_exists($itemType))
 		) {
 			return $getter($itemType, false);
+			
+		} elseif (
+			$method instanceof \ReflectionMethod
+			&& $parameter->isArray()
+			&& preg_match('#@param[ \t]+array<([\w\\\\]+)>[ \t]+\$' . $parameter->name . '#', (string) $method->getDocComment(), $m)
+			&& ($itemType = Reflection::expandClassName($m[1], $method->getDeclaringClass()))
+			&& (class_exists($itemType) || interface_exists($itemType))
+		) {
+			return $getter($itemType, false);
 
 		} elseif (($type && $parameter->allowsNull()) || $parameter->isOptional() || $parameter->isDefaultValueAvailable()) {
 			// !optional + defaultAvailable = func($a = null, $b) since 5.4.7

--- a/src/DI/Resolver.php
+++ b/src/DI/Resolver.php
@@ -554,7 +554,7 @@ class Resolver
 			&& (class_exists($itemType) || interface_exists($itemType))
 		) {
 			return $getter($itemType, false);
-			
+
 		} elseif (
 			$method instanceof \ReflectionMethod
 			&& $parameter->isArray()

--- a/src/DI/Resolver.php
+++ b/src/DI/Resolver.php
@@ -170,6 +170,7 @@ class Resolver
 		$this->currentServiceAllowed = $currentServiceAllowed;
 		$entity = $this->normalizeEntity($statement);
 		$arguments = $this->convertReferences($statement->arguments);
+		$arguments = Helpers::performFunctions($arguments);
 		$getter = function (string $type, bool $single) {
 			return $single
 				? $this->getByType($type)

--- a/src/DI/Resolver.php
+++ b/src/DI/Resolver.php
@@ -548,7 +548,7 @@ class Resolver
 
 		} elseif (
 			$method instanceof \ReflectionMethod
-			&& $parameter->isArray()
+			&& $type === 'array'
 			&& preg_match('#@param[ \t]+([\w\\\\]+)\[\][ \t]+\$' . $parameter->name . '#', (string) $method->getDocComment(), $m)
 			&& ($itemType = Reflection::expandClassName($m[1], $method->getDeclaringClass()))
 			&& (class_exists($itemType) || interface_exists($itemType))

--- a/tests/DI/Compiler.functions.phpt
+++ b/tests/DI/Compiler.functions.phpt
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * Test: Nette\DI\Compiler: internal functions.
+ */
+
+declare(strict_types=1);
+
+use Nette\DI;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+class Service
+{
+	public function __construct()
+	{
+	}
+
+
+	public function __call($nm, $args)
+	{
+		$this->args[$nm] = $args;
+	}
+}
+
+
+const NUM = 231;
+
+$compiler = new DI\Compiler;
+$compiler->setDynamicParameterNames(['dynamic']);
+$container = createContainer($compiler, '
+parameters:
+	t: true
+	f: false
+	fn: ::constant(NUM)
+	not: not(%f%)
+	string: string(%f%)
+
+services:
+	ok:
+		factory: Service
+		setup:
+		  	- not( not(%f%), not(%t%), not(%fn%), not(%dynamic%), %not% )
+		  	- string( string(%f%), string(%t%), string(%fn%), string(%dynamic%), %string% )
+		  	- bool( bool(%f%), bool(%t%) )
+		  	- int( int(%f%), int(%t%), int(%fn%), int(%dynamic%) )
+		  	- float( float(%f%), float(%t%), float(%fn%), float(%dynamic%) )
+
+	bad1: Service(bool(123))
+	bad2:
+		factory: Service
+		setup:
+			- method(bool(123))
+', ['dynamic' => 123]);
+
+
+$obj = $container->getByName('ok');
+
+Assert::same(
+	[
+		'not' => [true, false, false, false, true],
+		'string' => ['0', '1', '231', '123', '0'],
+		'bool' => [false, true],
+		'int' => [0, 1, 231, 123],
+		'float' => [0.0, 1.0, 231.0, 123.0],
+	],
+	$obj->args
+);
+
+Assert::exception(function () use ($container) {
+	$container->getByName('bad1');
+}, Nette\InvalidStateException::class, "Cannot convert '123' to bool.");
+
+Assert::exception(function () use ($container) {
+	$container->getByName('bad2');
+}, Nette\InvalidStateException::class, "Cannot convert '123' to bool.");
+
+
+// wrong arguments count
+Assert::exception(function () {
+	createContainer(new DI\Compiler, '
+	services:
+		- Service(bool(123, 10))
+	');
+}, Nette\InvalidStateException::class, 'Service of type Service: Function bool() expects at most 1 parameter, 2 given. (used in __construct())');

--- a/tests/DI/Definitions.AccessorDefinition.render.phpt
+++ b/tests/DI/Definitions.AccessorDefinition.render.phpt
@@ -35,7 +35,8 @@ test(function () {
 	$method = $phpGenerator->generateMethod($def);
 
 	Assert::match(
-'public function createServiceAbc(): Good2
+<<<'XX'
+public function createServiceAbc(): Good2
 {
 	return new class ($this) implements Good2 {
 		private $container;
@@ -49,8 +50,10 @@ test(function () {
 
 		public function get(): stdClass
 		{
-			return $this->container->getService(\'a\');
+			return $this->container->getService('a');
 		}
 	};
-}', $method->__toString());
+}
+XX
+, $method->__toString());
 });

--- a/tests/DI/Definitions.ImportedDefinition.phpt
+++ b/tests/DI/Definitions.ImportedDefinition.phpt
@@ -41,8 +41,11 @@ test(function () {
 	$method = $phpGenerator->generateMethod($def);
 
 	Assert::match(
-'public function createServiceAbc(): void
+<<<'XX'
+public function createServiceAbc(): void
 {
-	throw new Nette\DI\ServiceCreationException(\'Unable to create imported service \\\'abc\\\', it must be added using addService()\');
-}', $method->__toString());
+	throw new Nette\DI\ServiceCreationException('Unable to create imported service \'abc\', it must be added using addService()');
+}
+XX
+, $method->__toString());
 });

--- a/tests/DI/Definitions.LocatorDefinition.render.create.phpt
+++ b/tests/DI/Definitions.LocatorDefinition.render.create.phpt
@@ -36,11 +36,12 @@ test(function () {
 	$method = $phpGenerator->generateMethod($def);
 
 	Assert::match(
-'public function createServiceAbc(): Good
+<<<'XX'
+public function createServiceAbc(): Good
 {
 	return new class ($this) implements Good {
 		private $container;%A?%
-		private $mapping = [\'first\' => \'a\', \'second\' => \'a\'];
+		private $mapping = ['first' => 'a', 'second' => 'a'];
 
 
 		public function __construct($container)
@@ -52,10 +53,12 @@ test(function () {
 		public function create($name): stdClass
 		{
 			if (!isset($this->mapping[$name])) {
-				throw new Nette\DI\MissingServiceException("Service \'$name\' is not defined.");
+				throw new Nette\DI\MissingServiceException("Service '$name' is not defined.");
 			}
 			return $this->container->createService($this->mapping[$name]);
 		}
 	};
-}', $method->__toString());
+}
+XX
+, $method->__toString());
 });

--- a/tests/DI/Definitions.LocatorDefinition.render.get.phpt
+++ b/tests/DI/Definitions.LocatorDefinition.render.get.phpt
@@ -36,11 +36,12 @@ test(function () {
 	$method = $phpGenerator->generateMethod($def);
 
 	Assert::match(
-'public function createServiceAbc(): Good
+<<<'XX'
+public function createServiceAbc(): Good
 {
 	return new class ($this) implements Good {
 		private $container;%A?%
-		private $mapping = [\'first\' => \'a\', \'second\' => \'a\'];
+		private $mapping = ['first' => 'a', 'second' => 'a'];
 
 
 		public function __construct($container)
@@ -52,10 +53,12 @@ test(function () {
 		public function get($name): stdClass
 		{
 			if (!isset($this->mapping[$name])) {
-				throw new Nette\DI\MissingServiceException("Service \'$name\' is not defined.");
+				throw new Nette\DI\MissingServiceException("Service '$name' is not defined.");
 			}
 			return $this->container->getService($this->mapping[$name]);
 		}
 	};
-}', $method->__toString());
+}
+XX
+, $method->__toString());
 });

--- a/tests/DI/Definitions.LocatorDefinition.render.multi.phpt
+++ b/tests/DI/Definitions.LocatorDefinition.render.multi.phpt
@@ -38,7 +38,8 @@ test(function () {
 	$method = $phpGenerator->generateMethod($def);
 
 	Assert::match(
-'public function createServiceAbc(): Good
+<<<'XX'
+public function createServiceAbc(): Good
 {
 	return new class ($this) implements Good {
 		private $container;
@@ -58,8 +59,10 @@ test(function () {
 
 		public function getSecond(): ?stdClass
 		{
-			return $this->container->getService(\'a\');
+			return $this->container->getService('a');
 		}
 	};
-}', $method->__toString());
+}
+XX
+, $method->__toString());
 });

--- a/tests/DI/Helpers.convertType.phpt
+++ b/tests/DI/Helpers.convertType.phpt
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+use Nette\DI\Helpers;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+function testIt(string $type, $val, $res = null)
+{
+	if (func_num_args() === 3) {
+		Assert::same($res, Helpers::convertType($val, $type));
+	} else {
+		Assert::exception(function () use ($val, $type) {
+			Helpers::convertType($val, $type);
+		}, Nette\InvalidStateException::class);
+	}
+}
+
+
+$obj = new stdClass;
+
+testIt('string', null);
+testIt('string', []);
+testIt('string', $obj);
+testIt('string', '', '');
+testIt('string', 'a', 'a');
+testIt('string', '0', '0');
+testIt('string', '1', '1');
+testIt('string', '1.0', '1.0');
+testIt('string', '1.1', '1.1');
+testIt('string', '1a', '1a');
+testIt('string', true, '1');
+testIt('string', false, '0');
+testIt('string', 0, '0');
+testIt('string', 1, '1');
+testIt('string', 1.0, '1');
+testIt('string', 1.2, '1.2');
+
+testIt('int', null);
+testIt('int', []);
+testIt('int', $obj);
+testIt('int', '');
+testIt('int', 'a');
+testIt('int', '0', 0);
+testIt('int', '1', 1);
+testIt('int', '1.0');
+testIt('int', '1.1');
+testIt('int', '1a');
+testIt('int', true, 1);
+testIt('int', false, 0);
+testIt('int', 0, 0);
+testIt('int', 1, 1);
+testIt('int', 1.0, 1);
+testIt('int', 1.2);
+
+testIt('float', null);
+testIt('float', []);
+testIt('float', $obj);
+testIt('float', '');
+testIt('float', 'a');
+testIt('float', '0', 0.0);
+testIt('float', '1', 1.0);
+testIt('float', '1.', 1.0);
+testIt('float', '1.0', 1.0);
+testIt('float', '1.00', 1.0);
+testIt('float', '1..0');
+testIt('float', '1.1', 1.1);
+testIt('float', '1a');
+testIt('float', true, 1.0);
+testIt('float', false, 0.0);
+testIt('float', 0, 0.0);
+testIt('float', 1, 1.0);
+testIt('float', 1.0, 1.0);
+testIt('float', 1.2, 1.2);
+
+testIt('bool', null);
+testIt('bool', []);
+testIt('bool', $obj);
+testIt('bool', '');
+testIt('bool', 'a');
+testIt('bool', '1', true);
+testIt('bool', '1.0');
+testIt('bool', '1.1');
+testIt('bool', '1a');
+testIt('bool', true, true);
+testIt('bool', false, false);
+testIt('bool', 0, false);
+testIt('bool', 1, true);
+testIt('bool', 1.0, true);
+testIt('bool', 1.2);


### PR DESCRIPTION
- new feature
- BC break? most likely not

Supports `@param array<Abc\Xyz> $param` as alternative to `@param Abc\Xyz[] $param`. Code is duplicated, you might want to adjust the conditions a little.
