### PR TITLE
Resolver: autowire variadic parameters

### DIFF
--- a/tests/DI/ContainerBuilder.autowiring.variadic.phpt
+++ b/tests/DI/ContainerBuilder.autowiring.variadic.phpt
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Test: Nette\DI\ContainerBuilder and variadic parameters.
+ */
+
+declare(strict_types=1);
+
+use Nette\DI;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+class Foo
+{
+	public $bars;
+
+
+	public function __construct(Service ...$bars)
+	{
+		$this->bars = $bars;
+	}
+}
+
+class Service
+{
+}
+
+class ServiceChild extends Service
+{
+}
+
+
+$builder = new DI\ContainerBuilder;
+
+$builder->addDefinition('foo')
+	->setType('Foo');
+$builder->addDefinition('s1')
+	->setType('Service');
+$builder->addDefinition('s2')
+	->setType('Service');
+$builder->addDefinition('s3')
+	->setType('ServiceChild');
+$builder->addDefinition('s4')
+	->setType('stdClass');
+$builder->addDefinition('s5')
+	->setType('Service')
+	->setAutowired(false);
+$builder->addDefinition('fooWithExplicitBars')
+	->setType('Foo')
+	->setArgument('bars', [
+		$builder->getDefinition('s3'),
+		$builder->getDefinition('s5'),
+	]);
+
+$container = createContainer($builder);
+
+$foo = $container->getService('foo');
+Assert::type(Foo::class, $foo);
+Assert::same([
+	$container->getService('s1'),
+	$container->getService('s2'),
+	$container->getService('s3'),
+], $foo->bars);
+
+$fooWithExplicitBars = $container->getService('fooWithExplicitBars');
+Assert::type(Foo::class, $fooWithExplicitBars);
+Assert::same([
+	$container->getService('s3'),
+	$container->getService('s5'),
+], $fooWithExplicitBars->bars);
+
+
+// runtime
+
+$foo2 = $container->createInstance('Foo');
+Assert::type(Foo::class, $foo2);
+Assert::same([
+	$container->getService('s1'),
+	$container->getService('s2'),
+	$container->getService('s3'),
+], $foo2->bars);

--- a/tests/DI/Resolver.autowireArguments.phpt
+++ b/tests/DI/Resolver.autowireArguments.phpt
@@ -23,6 +23,11 @@ class Test
 	public function methodNullable(?self $class, ?self $self, ?Undefined $nullable1, ?int $nullable2)
 	{
 	}
+
+
+	public function methodVariadic(self ...$variadic)
+	{
+	}
 }
 
 Assert::equal(
@@ -36,5 +41,26 @@ Assert::equal(
 	[new Test, new Test, null, null],
 	Resolver::autowireArguments(new ReflectionMethod('Test', 'methodNullable'), [], function ($type) {
 		return $type === 'Test' ? new Test : null;
+	})
+);
+
+Assert::equal(
+	[new Test, new Test],
+	Resolver::autowireArguments(new ReflectionMethod('Test', 'methodVariadic'), [], function ($type) {
+		return $type === 'Test' ? [new Test, new Test] : [];
+	})
+);
+
+Assert::equal(
+	[new Test, new Test, new Test],
+	Resolver::autowireArguments(new ReflectionMethod('Test', 'methodVariadic'), [new Test, new Test, new Test], function ($type) {
+		return [];
+	})
+);
+
+Assert::equal(
+	[new Test, new Test, new Test],
+	Resolver::autowireArguments(new ReflectionMethod('Test', 'methodVariadic'), ['variadic' => [new Test, new Test, new Test]], function ($type) {
+		return [];
 	})
 );


### PR DESCRIPTION
- new feature
- BC break: no
- doc PR: *todo*

Hi there, in addition to autowiring arrays of services via annotations, I think it might be useful to autowire variadic arguments as well – it's a very similar mechanism, but with added type safety on the language level:

```php
final class ApplicationPermissionsConfigurator
{
    /** @var ModulePermissionsConfigurator[] */
    private array $moduleConfigurators;

    public function __construct(ModulePermissionsConfigurator ...$moduleConfigurators) {
        $this->moduleConfigurators = $moduleConfigurators;
    }
}
```