### PR TITLE
Resolver: More better exception in case of accessor or factory is defined as regular service.

### DIFF
--- a/src/DI/Extensions/DIExtension.php
+++ b/src/DI/Extensions/DIExtension.php
@@ -36,7 +36,7 @@ final class DIExtension extends Nette\DI\CompilerExtension
 		$this->time = microtime(true);
 
 		$this->config = new class {
-			/** @var bool */
+			/** @var ?bool */
 			public $debugger;
 			/** @var string[] */
 			public $excluded = [];
@@ -53,7 +53,6 @@ final class DIExtension extends Nette\DI\CompilerExtension
 			/** @var string[]|bool|null */
 			public $types = true;
 		};
-		$this->config->debugger = interface_exists(\Tracy\IBarPanel::class);
 	}
 
 
@@ -81,7 +80,10 @@ final class DIExtension extends Nette\DI\CompilerExtension
 		$this->restrictTags($class);
 		$this->restrictTypes($class);
 
-		if ($this->debugMode && $this->config->debugger) {
+		if (
+			$this->debugMode &&
+			($this->config->debugger ?? $this->getContainerBuilder()->getByType(\Tracy\Bar::class))
+		) {
 			$this->enableTracyIntegration();
 		}
 

--- a/src/DI/Resolver.php
+++ b/src/DI/Resolver.php
@@ -135,7 +135,7 @@ class Resolver
 		} elseif (is_string($entity)) { // class
 			if (!class_exists($entity)) {
 				throw new ServiceCreationException(interface_exists($entity)
-					? "Interface $entity can not be used as 'factory', did you mean 'implement'?"
+					? "Interface $entity can not be used as 'factory', did you mean 'implement' or do you want use addFactoryDefinition() or addAccessorDefinition() with method setImplement()?"
 					: "Class $entity not found."
 				);
 			}


### PR DESCRIPTION
- bug fix
- BC break? no

In the case of the interface (factory or accessor) is defined as regular service, DI should throw a more helpful exception.

For example (broken code in extension):

```php
$builder->addDefinition($this->prefix('doctrineHelperAccessor'))
	->setFactory(DoctrineHelperAccessor::class);
```

This code should be rewritten to:

```php
$builder->addAccessorDefinition($this->prefix('doctrineHelperAccessor'))
	->setImplement(DoctrineHelperAccessor::class);
```

Thanks!