### PR TITLE
DecoratorExtension: throws exception if class not exists

### DIFF
--- a/src/DI/Extensions/DecoratorExtension.php
+++ b/src/DI/Extensions/DecoratorExtension.php
@@ -34,7 +34,7 @@ final class DecoratorExtension extends Nette\DI\CompilerExtension
 	{
 		$this->getContainerBuilder()->resolve();
 		foreach ($this->config as $type => $info) {
-			if (!class_exists($type)) {
+			if (!class_exists($type) && !interface_exists($type)) {
 				throw new Nette\DI\InvalidConfigurationException("Decorator class '$type' not found.");
 			}
 			if ($info->inject !== null) {

--- a/src/DI/Extensions/DecoratorExtension.php
+++ b/src/DI/Extensions/DecoratorExtension.php
@@ -34,6 +34,9 @@ final class DecoratorExtension extends Nette\DI\CompilerExtension
 	{
 		$this->getContainerBuilder()->resolve();
 		foreach ($this->config as $type => $info) {
+			if (!class_exists($type)) {
+				throw new Nette\DI\InvalidConfigurationException("Decorator class '$type' not found.");
+			}
 			if ($info->inject !== null) {
 				$info->tags[InjectExtension::TAG_INJECT] = $info->inject;
 			}


### PR DESCRIPTION
Maybe change `!class_exists($type)` to `!class_exists($type) && !interface_exists($type)`, but I don't use decorator interfaces