### PR TITLE
Better sorting for human eyes

### DIFF
--- a/src/Bridges/DITracy/ContainerPanel.php
+++ b/src/Bridges/DITracy/ContainerPanel.php
@@ -66,7 +66,7 @@ class ContainerPanel implements Tracy\IBarPanel
 			}
 		}
 		$types = $this->getContainerProperty('types') + $types;
-		ksort($types);
+		ksort($types, SORT_NATURAL);
 		foreach ($this->getContainerProperty('tags') as $tag => $tmp) {
 			foreach ($tmp as $service => $val) {
 				$tags[$service][$tag] = $val;


### PR DESCRIPTION
- bug fix
- BC break? no

Better sorting strings containing integers.

## Before

Name | Autowired | Service
-- | -- | --
application.1 | yes | App\MyService
application.10 | yes | App\FooService
application.11 | yes | App\BarService
application.12 | no | App\FooBarService
application.2 | yes | App\Foo
application.3 | yes | App\Bar

## Now
Name | Autowired | Service
-- | -- | --
application.1 | yes | App\MyService
application.2 | yes | App\FooService
application.3 | yes | App\BarService
application.4 | no | App\FooBarService
application.5 | yes | App\Foo
application.6 | yes | App\Bar
