### PR TITLE
Fix silencing file_get_contents file not not found warning

### DIFF
--- a/src/DI/ContainerLoader.php
+++ b/src/DI/ContainerLoader.php
@@ -99,7 +99,7 @@ class ContainerLoader
 	private function isExpired(string $file, string &$updatedMeta = null): bool
 	{
 		if ($this->autoRebuild) {
-			$meta = @unserialize((string) file_get_contents("$file.meta")); // @ - file may not exist
+			$meta = @unserialize((string) @file_get_contents("$file.meta")); // @ - file may not exist
 			$orig = $meta[2] ?? null;
 			return empty($meta[0])
 				|| DependencyChecker::isExpired(...$meta)


### PR DESCRIPTION
- bug fix   <!-- #issue numbers, if any -->
- BC break? no

Hi. `file_get_contents` might produce a warning if the file isn't found. There is a comment `@ - file may not exist`, but `@` was mistakenly placed on `unserialize`.

<!--
Describe your changes here to communicate to the maintainers why we should accept this pull request.

Please add new tests to show the fix or feature works. And take a moment to read the contributing guide https://nette.org/en/contributing

Thanks for contributing to Nette!
-->
