### PR TITLE
fix Container::getByType() compatibility with PHPStan

### DIFF
--- a/src/DI/Container.php
+++ b/src/DI/Container.php
@@ -221,7 +221,7 @@ class Container
 
 	/**
 	 * Resolves service by type.
-	 * @template T
+	 * @template T of object
 	 * @param  class-string<T>  $type
 	 * @return ?T
 	 * @throws MissingServiceException


### PR DESCRIPTION
Without specifying the upper bound, PHPStan fails to resolve the return type.