### PR TITLE
Support `list<Type>` syntax for autowiring a collection of services

### DIFF
--- a/src/DI/Resolver.php
+++ b/src/DI/Resolver.php
@@ -590,7 +590,7 @@ class Resolver
 		return $method instanceof \ReflectionMethod
 			&& $type?->getSingleName() === 'array'
 			&& preg_match(
-				'#@param[ \t]+(?|([\w\\\\]+)\[\]|array<int,\s*([\w\\\\]+)>)[ \t]+\$' . $parameter->name . '#',
+				'#@param[ \t]+(?|([\w\\\\]+)\[\]|list<([\w\\\\]+)>|array<int,\s*([\w\\\\]+)>)[ \t]+\$' . $parameter->name . '#',
 				(string) $method->getDocComment(),
 				$m,
 			)

--- a/tests/DI/ContainerBuilder.autowiring.type[].phpt
+++ b/tests/DI/ContainerBuilder.autowiring.type[].phpt
@@ -16,18 +16,21 @@ require __DIR__ . '/../bootstrap.php';
 class Foo
 {
 	public $bars;
+	public $waldos;
 	public $foos;
 	public $strings;
 
 
 	/**
 	 * @param Service[] $bars
+	 * @param list<Service> $waldos
 	 * @param array<int,Foo> $foos
 	 * @param string[] $strings
 	 */
-	public function __construct(array $bars = [], ?array $foos = null, array $strings = ['default'])
+	public function __construct(array $bars = [], array $waldos = [], ?array $foos = null, array $strings = ['default'])
 	{
 		$this->bars = $bars;
+		$this->waldos = $waldos;
 		$this->foos = $foos;
 		$this->strings = $strings;
 	}
@@ -67,6 +70,11 @@ Assert::same([
 	$container->getService('s2'),
 	$container->getService('s3'),
 ], $foo->bars);
+Assert::same([
+	$container->getService('s1'),
+	$container->getService('s2'),
+	$container->getService('s3'),
+], $foo->waldos);
 Assert::same([], $foo->foos);
 Assert::same(['default'], $foo->strings);
 
@@ -80,5 +88,10 @@ Assert::same([
 	$container->getService('s2'),
 	$container->getService('s3'),
 ], $foo2->bars);
+Assert::same([
+	$container->getService('s1'),
+	$container->getService('s2'),
+	$container->getService('s3'),
+], $foo2->waldos);
 Assert::same([$foo], $foo2->foos); // difference
 Assert::same(['default'], $foo2->strings);


### PR DESCRIPTION
- bug fix / new feature?

New feature
[Autowiring a collection of services](https://doc.nette.org/en/dependency-injection/autowiring#toc-collection-of-services) already supports `@param Type[] $foo` and `@param array<int, Type>`, and using `@param list<Type> $foo` is basically the same thing in this case. For some people, like me, using `list<>` better indicates that the key of the array can be ignored (or can be assumed sequential).

- BC break? yes/no

no

- doc PR: nette/docs#???  <!-- highly welcome, see https://nette.org/en/writing -->

https://github.com/nette/docs/pull/1031

<!--
Please use the latest released version (ie. last tagged commit) as a base for PR.

Describe your changes here to communicate to the maintainers why we should accept this pull request.

Please add new tests to show the fix or feature works. And take a moment to read the contributing guide https://nette.org/en/contributing

Thanks for contributing to Nette!
-->
