### PR TITLE
ServicesExtension: locator support Statement

### DIFF
--- a/src/DI/Extensions/ServicesExtension.php
+++ b/src/DI/Extensions/ServicesExtension.php
@@ -186,6 +186,16 @@ final class ServicesExtension extends Nette\DI\CompilerExtension
 		}
 
 		if (isset($config->references)) {
+			foreach ($config->references as $name => $reference) {
+				if ($reference instanceof Statement) {
+					$config->references[$name] = '@' . $this->getContainerBuilder()
+							->addDefinition(null)
+							->setFactory($reference)
+							->setAutowired(false)
+							->getName();
+				}
+			}
+
 			$definition->setReferences($config->references);
 		}
 

--- a/tests/DI/Compiler.generatedLocator.phpt
+++ b/tests/DI/Compiler.generatedLocator.phpt
@@ -68,6 +68,7 @@ services:
 	five: LocatorN(tagged: a)
 	six: LocatorFactoryN(tagged: a)
 	seven: Locator(a: @lorem1)
+	eight: Locator(a: LoremChild())
 ');
 
 
@@ -116,3 +117,8 @@ Assert::null($six->create('3'));
 // accessor with one service
 $one = $container->getService('seven');
 Assert::type(Lorem::class, $one->get('a'));
+
+// accessor with custom defined classes
+$one = $container->getService('eight');
+Assert::type(LoremChild::class, $one->get('a'));
+Assert::notSame($container->getByType(LoremChild::class), $one->get('a'));


### PR DESCRIPTION
- bug fix / new feature?   new feature
- BC break? no
- doc PR: nette/docs#???  <!-- highly welcome, see https://nette.org/en/writing -->


## Example

In example I used classes from my library, if you want to try, let's use `composer require h4kuna/number-format:dev-mater`, but i think it is not necessary.

I want to define custom collection of formats

```neon 
services:
	format.date:
		factory: h4kuna\Format\Date\Formatters\DateTimeFormatter('j.n.Y')
		autowired: false
	format.time:
		factory: h4kuna\Format\Date\Formatters\DateTimeFormatter('H:i:s')
		autowired: false

	date.formats: h4kuna\Format\Date\FormatsAccessor(
		date: @format.date
		time: @format.time
	)

	# set to template, but it is not need for example
	latte.latteFactory:
		setup:
			- addFilter('date', @date.formats::get('date'))
			- addFilter('time', @date.formats::get('time'))
```

The original way is too chatty, the patch allow
```neon 
services:
	date.formats: h4kuna\Format\Date\FormatsAccessor(
		date: h4kuna\Format\Date\Formatters\DateTimeFormatter('j.n.Y')
		time: h4kuna\Format\Date\Formatters\DateTimeFormatter('H:i:s')
	)
```

I don't  need class with option `autowired: true` explicitly to register to container. But behavior is same like above.

What do you think?