### PR TITLE
Test for "Nette DI: suspicious dumping of objects DateTimeImmutable when generating the container"

### DIFF
--- a/tests/DI/Compiler.parameters.phpt
+++ b/tests/DI/Compiler.parameters.phpt
@@ -68,6 +68,19 @@ test('Statement within string expansion', function () {
 });
 
 
+test('Statement with datetime', function () {
+	$compiler = new DI\Compiler;
+	$container = createContainer($compiler, '
+	parameters:
+		datetime: 2000-01-01 00:00:00 +0000
+
+	services:
+		one: Service(%datetime%)
+	');
+
+	Assert::same('2000-01-01', $container->getService('one')->arg->format('Y-m-d'));
+});
+
 test('Statement within array expansion', function () {
 	$compiler = new DI\Compiler;
 	$container = createContainer($compiler, '


### PR DESCRIPTION
`DateTimeImmutable` throws user notice since version 3.2.0:

```
E_USER_NOTICE: Nette DI: suspicious dumping of objects DateTimeImmutable when generating the container
```

PR contains failing test.