### PR TITLE
used generics for Container::createInstance()

### DIFF
--- a/src/DI/Container.php
+++ b/src/DI/Container.php
@@ -320,6 +320,9 @@ class Container
 
 	/**
 	 * Creates an instance of the class and passes dependencies to the constructor using autowiring.
+	 * @template T of object
+	 * @param  class-string<T>  $class
+	 * @return T
 	 */
 	public function createInstance(string $class, array $args = []): object
 	{


### PR DESCRIPTION
- phpDoc improvement
- BC break? no

Should bring identical benefit that `getByType` already enjoys.