### PR TITLE
CLAUDE.md: fix multifactory list example (Article → Article())

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -822,7 +822,7 @@ interface MultiFactory
 ```neon
 services:
 	- MultiFactory(
-		article: Article
+		article: Article()
 		db: PDO(%dsn%, %user%, %password%)
 	)
 ```


### PR DESCRIPTION
### Problem

In `CLAUDE.md`, the **"Definition with list"** example for a multifactory is broken:

```neon
services:
	- MultiFactory(
		article: Article        # ← does not compile
		db: PDO(%dsn%, %user%, %password%)
	)
```

`article: Article` (a bare string) is parsed as a **reference to an existing service** of type `Article` (`Reference::fromType()` in `LocatorDefinition`), not as an inline definition. Since no such service is registered, compilation fails with:

```
Nette\DI\ServiceCreationException: Service of type MultiFactory: Service of type Article not found.
```

Only statements (values with parentheses) are turned into anonymous services inside a locator list.

### Fix

Add the parentheses so it is an inline definition:

```neon
		article: Article()
```

Verified by compiling the example against the current sources — with `Article()` the container builds and `createArticle()` returns a new `Article`, `getDb()` returns the shared `PDO`.

The second example in the same section (with `@article` references) is correct and left unchanged.

_Found during a documentation audit of nette/documentation; the same fix was applied there._