### PR TITLE
Improve file retrieval logic in DependencyChecker

### DIFF
--- a/src/DI/DependencyChecker.php
+++ b/src/DI/DependencyChecker.php
@@ -56,7 +56,10 @@ class DependencyChecker
 					$all = [$name] + class_parents($name) + class_implements($name);
 					foreach ($all as &$item) {
 						$all += class_uses($item);
-						$phpFiles[] = (new ReflectionClass($item))->getFileName();
+						$rc = new ReflectionClass($item);
+						if ($file = $rc->getFileName()) {
+                            $phpFiles[] = $file;
+                        }
 						$classes[$item] = true;
 					}
 				}


### PR DESCRIPTION
Refactor file retrieval for ReflectionClass instances.

- bug fix
- BC break? no

in PHP 8+ filemtime in strict_types=1 mode => filemtime(): Argument #1 ($filename) must be of type string, false given